### PR TITLE
Changed uninstall-cp4waiops.sh to use specifically use bash 

### DIFF
--- a/uninstall/3.1/uninstall-cp4waiops.sh
+++ b/uninstall/3.1/uninstall-cp4waiops.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2020- IBM Inc. All rights reserved
 # SPDX-License-Identifier: Apache2.0


### PR DESCRIPTION
Shebang lines were inconsistent (sh in one file, bash in another), and using sh causes compatibility issues since the scripts were only tested in bash.