### PR TITLE
Added oc delete operandbindinfo in ibm-common-services ns as seen in …

### DIFF
--- a/uninstall/3.1/uninstall-cp4waiops-helper.sh
+++ b/uninstall/3.1/uninstall-cp4waiops-helper.sh
@@ -301,6 +301,8 @@ delete_iaf_bedrock () {
     done
     log $INFO "Expected operandrequests got deleted successfully!"
 
+    # Deleting operandbindinfo before namespacescopes as seen in iaf internal uninstall script
+    oc delete operandbindinfo --all -n ibm-common-services --ignore-not-found
     oc delete namespacescopes common-service -n ibm-common-services --ignore-not-found
     oc delete namespacescopes nss-managedby-odlm -n ibm-common-services --ignore-not-found
     oc delete namespacescopes odlm-scope-managedby-odlm -n ibm-common-services --ignore-not-found


### PR DESCRIPTION
…internal IAF uninstall script. Attempts to solve the problem where uninstall will sometimes leave behind namespacescopes in automated tests despite explicit deletion.