### PR TITLE
Check ibm-common-service subscriptions in all namespaces

### DIFF
--- a/infrastructure-automation/infrastructureAutomation.sh
+++ b/infrastructure-automation/infrastructureAutomation.sh
@@ -1140,7 +1140,7 @@ installFunc() {
     echo "**********************************************************************" | tee -a "$logpath"
     echo "" | tee -a "$logpath"
     echo "Checking if Common Service is already installed."
-    oc -n openshift-operators get subscriptions | grep ibm-common-service-operator > /dev/null 2>&1
+    oc get subscriptions -A | grep ibm-common-service-operator > /dev/null 2>&1
     local result=$?
     if [[ "${result}" -ne 0 ]]; then
         echo "Creating Common Service Catalog Source."


### PR DESCRIPTION
Current code only check the ibm-common-services-operator subscription in the openshift-operators but it can be in any namespace. Update the code to check for all namespaces.