### PR TITLE
Flesh out status checker tool for install/deployment status

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -20,6 +20,21 @@ echo "
 |                                                          |
 |  If your install is in a namespace called \"cp4waiops\",   |
 |  then no change to this script is required.              | 
+|                                                          |
+|  After running the status checker script, if the         |
+|  components listed below have successfully installed,    |
+|  each component's Status/Phase will indicate this in     |
+|  the list below as Completed/Configured/True/etc.        |
+|                                                          |
+|  However, if there are components that are not           |
+|  fully reconciled yet, please refer to their pod logs    |
+|  for more information. If only a short time has passed   |
+|  since the install was started, the components may       |
+|  need more time to complete fully. If you have waited    |
+|  a significant amount of time and the components         |
+|  listed below are not indicating completion or success,  |
+|  please refer to the troubleshooting docs or open        |
+|  a support case.                                         |
 |__________________________________________________________|
 "
 export PROJECT_NAMESPACE="cp4waiops"
@@ -83,7 +98,15 @@ then
 
     echo "______________________________________________________________"
     echo "Subscriptions from ibm-common-services namespace:" && echo ""
-    oc get subscriptions -n ibm-common-services 
+    oc get subscriptions -n ibm-common-services
+
+    echo "______________________________________________________________"
+    echo "ODLM pod current status:" && echo ""
+    oc get pod -n ibm-common-services | grep operand-deployment-lifecycle-manager
+
+    echo "______________________________________________________________"
+    echo "Orchestrator pod current status:" && echo ""
+    oc get pod -n cp4waiops | grep ibm-aiops-orchestrator-controller-manager
     
     echo ""
     exit 0

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -14,16 +14,8 @@ white=$(tput setaf 7)
 bold=$(tput bold)
 normal=$(tput sgr0) #reset color/bolding
 
-export CP4WAIOPS_VERSION="3.3"
-
-# Get installation namespace
-if [ "$PROJECT_NAMESPACE" == "" ]
-then
-    printf "
-${bold}${blue}Enter your Cloud Pak for Watson AIOps installation namespace: ${normal}"
-    read PROJECT_NAMESPACE
-    oc project ${PROJECT_NAMESPACE}
-fi
+# Get installation namespace (inferred from location of orchestrator pod)
+PROJECT_NAMESPACE=$(oc get pods --all-namespaces|grep ibm-aiops-orchestrator|awk '{print $1}')
 
 # optional argument handling
 if [[ "$1" == "version" ]]
@@ -42,228 +34,69 @@ fi
 # optional argument handling
 if [[ "$1" == "status" ]]
 then
-    if [[ "$CP4WAIOPS_VERSION" == "3.3" ]]
-    then
-        echo "______________________________________________________________"
-        echo "Installation instances:" && echo ""
-        oc get installations.orchestrator.aiops.ibm.com -A 
-        
-        echo "______________________________________________________________"
-        echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
-        oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
-        
-        echo "______________________________________________________________"
-        echo "LifecycleService instances:" && echo ""
-        oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason"
-        
-        echo "______________________________________________________________"
-        echo "BaseUI instances:" && echo ""
-        oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
-        
-        echo "______________________________________________________________"
-        echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
-        oc get AIManager,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
-        oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase" && echo ""
-        oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled"
-
-        echo "______________________________________________________________"
-        echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
-        oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status'
-        
-        echo "______________________________________________________________"
-        echo "Kong instances:" && echo ""
-        oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name"         
-        
-        echo "______________________________________________________________"
-        echo "ZenService instances:" && echo ""
-        oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
-        
-        echo "______________________________________________________________"
-        echo "CSVs from $PROJECT_NAMESPACE namespace:" && echo ""
-        oc get csvs -n $PROJECT_NAMESPACE 
+    echo "______________________________________________________________"
+    echo "Installation instances:" && echo ""
+    oc get installations.orchestrator.aiops.ibm.com -A 
     
-        echo "______________________________________________________________"
-        echo "CSVs from ibm-common-services namespace:" && echo ""
-        oc get csvs -n ibm-common-services
+    echo "______________________________________________________________"
+    echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
+    oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "LifecycleService instances:" && echo ""
+    oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "BaseUI instances:" && echo ""
+    oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
+    oc get AIManager,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
+    oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase" && echo ""
+    oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled"
 
-        echo "______________________________________________________________"
-        echo "Subscriptions from $PROJECT_NAMESPACE namespace:" && echo ""
-        oc get subscriptions -n $PROJECT_NAMESPACE 
+    echo "______________________________________________________________"
+    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
+    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status'
+    
+    echo "______________________________________________________________"
+    echo "Kong instances:" && echo ""
+    oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name"         
+    
+    echo "______________________________________________________________"
+    echo "ZenService instances:" && echo ""
+    oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus'
+    
+    echo "______________________________________________________________"
+    echo "CSVs from $PROJECT_NAMESPACE namespace:" && echo ""
+    oc get csvs -n $PROJECT_NAMESPACE 
 
-        echo "______________________________________________________________"
-        echo "Subscriptions from ibm-common-services namespace:" && echo ""
-        oc get subscriptions -n ibm-common-services
-        
-        echo "______________________________________________________________"
-        echo "OperandRequest instances:" && echo ""
-        oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp"
-        
-        echo "______________________________________________________________"
-        echo "ODLM pod current status:" && echo ""
-        oc get pod -n ibm-common-services | grep operand-deployment-lifecycle-manager
+    echo "______________________________________________________________"
+    echo "CSVs from ibm-common-services namespace:" && echo ""
+    oc get csvs -n ibm-common-services
 
-        echo "______________________________________________________________"
-        echo "Orchestrator pod current status:" && echo ""
-        oc get pod -n $PROJECT_NAMESPACE | grep ibm-aiops-orchestrator-controller-manager
-        
-        echo ""
-    else
-        echo "Sorry, this tool only supports CP4WAIOps v3.3 at this time. 
+    echo "______________________________________________________________"
+    echo "Subscriptions from $PROJECT_NAMESPACE namespace:" && echo ""
+    oc get subscriptions -n $PROJECT_NAMESPACE 
 
-You currently have your CP4WAIOps version in this script set to \"$CP4WAIOPS_VERSION\". 
+    echo "______________________________________________________________"
+    echo "Subscriptions from ibm-common-services namespace:" && echo ""
+    oc get subscriptions -n ibm-common-services
+    
+    echo "______________________________________________________________"
+    echo "OperandRequest instances:" && echo ""
+    oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp"
+    
+    echo "______________________________________________________________"
+    echo "ODLM pod current status:" && echo ""
+    oc get pod -A | grep operand-deployment-lifecycle-manager
 
-If this is incorrect, please update the \`CP4WAIOPS_VERSION\` variable
-in this script to \"3.3\" and run \`oc waiops status\` again.
-"
-    fi
-    exit 0
-fi
 
-# optional argument handling
-if [[ "$1" == "upgrade-status" ]]
-then
-    # Script to check upgrade status of CP4WAIOps install for v3.3
-    # This script checks to see if your Cloud Pak for Watson AIOps
-    # instance is properly configured post-upgrade for v3.3. 
-
-    FAILING_UPGRADE=""
-    SUCCESSFULLY_UPGRADED=""
-
-    aiopsEdgeBaseUpgradeStatus() {    
-        UPGRADED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.conditions[?(@.type=="UpgradeReady")].status}')
-        DETAILS=$(oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase")
-        if [ "${UPGRADED}" == "True" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    aiopsUIUpgradeStatus() {    
-        CURRENT_MAJOR_VERSION=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
-        DETAILS=$(oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled")
-        if [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    kongUpgradeStatus() {    
-        INITIALIZED=$(oc get kong gateway -o jsonpath='{.status.conditions[?(@.type=="Initialized")].status}')
-        DEPLOYED=$(oc get kong gateway -o jsonpath='{.status.conditions[?(@.type=="Deployed")].status}')
-        DETAILS=$(oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name")
-        if [ "${INITIALIZED}" == "True" ] && [ "${DEPLOYED}" == "True" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    aiManagerUpgradeStatus() {    
-        PHASE_STATUS=$(oc get aimanager aimanager -o jsonpath='{.status.phase}')
-        CURRENT_MAJOR_VERSION=$(oc get aimanager aimanager -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
-        DETAILS=$(oc get aimanager -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase")
-        if [ "${PHASE_STATUS}" == "Completed" ] && [ "${CURRENT_MAJOR_VERSION}" == "2.4" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    irCoreUpgradeStatus() {
-        UPGRADED=$(oc get ircore aiops -o json | jq '.metadata.generation as $generation|[(.status.conditions[]|select(.type=="Ready")|.status == "True" and .observedGeneration == $generation)]|all')
-        CURRENT_MAJOR_VERSION=$(oc get ircore aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
-        DETAILS=$(oc get ircore -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason")
-        if [ "${UPGRADED}" == true ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    lifecycleUpgradeStatus() {
-        UPGRADED=$(oc get lifecycleservices aiops -o json | jq '.metadata.generation as $generation|[(.status.conditions[]|select(.type=="Ready")|.status == "True"), (.status.observedGeneration == $generation)]|all')
-        CURRENT_MAJOR_VERSION=$(oc get lifecycleservices aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
-        DETAILS=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason")
-        if [ "${UPGRADED}" == true ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    aiopsAnalyticsUpgradeStatus() {
-        UPGRADED=$(oc get AIOpsAnalyticsOrchestrator aiops -o json | jq '.metadata.generation as $generation|[(.status.conditions[]|select(.type=="Ready")|.status == "True" and .observedGeneration == $generation)]|all')
-        CURRENT_MAJOR_VERSION=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
-        DETAILS=$(oc get AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason")
-        if [ "${UPGRADED}" == true ] && [ "${CURRENT_MAJOR_VERSION}" == "3.2" ];
-        then 
-            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
-            return 0;
-        else 
-            FAILING_UPGRADE+="${newline}${DETAILS}"
-            return 1;
-        fi
-    }
-
-    # Run component status checks
-    aiopsEdgeBaseUpgradeStatus
-    lifecycleUpgradeStatus
-    aiopsUIUpgradeStatus
-    kongUpgradeStatus
-    aiManagerUpgradeStatus
-    irCoreUpgradeStatus
-    aiopsAnalyticsUpgradeStatus
-
-    # Print out results of status checks
-    printf "
-${bold}${green}______________________________________________________________
-
-The following component(s) have finished upgrading:
-${normal}${SUCCESSFULLY_UPGRADED}
-
-${bold}${green}______________________________________________________________
-"
-    if [ "$FAILING_UPGRADE" != "" ];
-    then 
-        printf "
-${bold}${red}______________________________________________________________
-
-Meanwhile, the following component(s) have not upgraded yet:
-${normal}${FAILING_UPGRADE}
-
-If only a short time has passed since the upgrade was started, the components may
-need more time to complete upgrading. If you have waited a significant amount of time
-and the statuses of the components listed below are not changing, please refer to
-the troubleshooting docs or open a support case.
-
-${bold}${red}______________________________________________________________
-";
-    fi
-
-    printf "
-${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status\`.
-${normal}
-"
+    echo "______________________________________________________________"
+    echo "Orchestrator pod current status:" && echo ""
+    oc get pod -A | grep ibm-aiops-orchestrator-controller-manager    
+    echo ""
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -37,7 +37,11 @@ echo "
 |  a support case.                                         |
 |__________________________________________________________|
 "
+# Please update PROJECT_NAMESPACE below to your installation namespace.
+# By default in this script, this is set to "cp4waiops".
 export PROJECT_NAMESPACE="cp4waiops"
+
+export CP4WAIOPS_VERSION="3.3"
 
 # optional argument handling
 if [[ "$1" == "version" ]]
@@ -56,63 +60,74 @@ fi
 # optional argument handling
 if [[ "$1" == "status" ]]
 then
-    echo "______________________________________________________________"
-    echo "Installation instances:" && echo ""
-    oc get installations.orchestrator.aiops.ibm.com -A 
+    if [[ "$CP4WAIOPS_VERSION" == "3.3" ]]
+    then
+        echo "______________________________________________________________"
+        echo "Installation instances:" && echo ""
+        oc get installations.orchestrator.aiops.ibm.com -A 
+        
+        echo "______________________________________________________________"
+        echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
+        oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
+        
+        echo "______________________________________________________________"
+        echo "LifecycleService instances:" && echo ""
+        oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason"
+        
+        echo "______________________________________________________________"
+        echo "BaseUI instances:" && echo ""
+        oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
+        
+        echo "______________________________________________________________"
+        echo "AIManager, AIOpsEdge, and ASM instances:" && echo ""
+        oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
+        
+        echo "______________________________________________________________"
+        echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
+        oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status'
+        
+        echo "______________________________________________________________"
+        echo "ZenService instances:" && echo ""
+        oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+        
+        echo "______________________________________________________________"
+        echo "CSVs from $PROJECT_NAMESPACE namespace:" && echo ""
+        oc get csvs -n $PROJECT_NAMESPACE 
     
-    echo "______________________________________________________________"
-    echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
-    oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
-    
-    echo "______________________________________________________________"
-    echo "LifecycleService instances:" && echo ""
-    oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason"
-    
-    echo "______________________________________________________________"
-    echo "BaseUI instances:" && echo ""
-    oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
-    
-    echo "______________________________________________________________"
-    echo "AIManager, AIOpsEdge, and ASM instances:" && echo ""
-    oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
-    
-    echo "______________________________________________________________"
-    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
-    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:spec.version,STATUS:.status.conditions[?(@.type=="Ready")].status'
-    
-    echo "______________________________________________________________"
-    echo "ZenService instances:" && echo ""
-    oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
-    
-    echo "______________________________________________________________"
-    echo "CSVs from $PROJECT_NAMESPACE namespace:" && echo ""
-    oc get csvs -n $PROJECT_NAMESPACE 
- 
-    echo "______________________________________________________________"
-    echo "CSVs from ibm-common-services namespace:" && echo ""
-    oc get csvs -n ibm-common-services
+        echo "______________________________________________________________"
+        echo "CSVs from ibm-common-services namespace:" && echo ""
+        oc get csvs -n ibm-common-services
 
-    echo "______________________________________________________________"
-    echo "Subscriptions from $PROJECT_NAMESPACE namespace:" && echo ""
-    oc get subscriptions -n $PROJECT_NAMESPACE 
+        echo "______________________________________________________________"
+        echo "Subscriptions from $PROJECT_NAMESPACE namespace:" && echo ""
+        oc get subscriptions -n $PROJECT_NAMESPACE 
 
-    echo "______________________________________________________________"
-    echo "Subscriptions from ibm-common-services namespace:" && echo ""
-    oc get subscriptions -n ibm-common-services
-    
-    echo "______________________________________________________________"
-    echo "OperandRequest instances:" && echo ""
-    oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp"
-    
-    echo "______________________________________________________________"
-    echo "ODLM pod current status:" && echo ""
-    oc get pod -n ibm-common-services | grep operand-deployment-lifecycle-manager
+        echo "______________________________________________________________"
+        echo "Subscriptions from ibm-common-services namespace:" && echo ""
+        oc get subscriptions -n ibm-common-services
+        
+        echo "______________________________________________________________"
+        echo "OperandRequest instances:" && echo ""
+        oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp"
+        
+        echo "______________________________________________________________"
+        echo "ODLM pod current status:" && echo ""
+        oc get pod -n ibm-common-services | grep operand-deployment-lifecycle-manager
 
-    echo "______________________________________________________________"
-    echo "Orchestrator pod current status:" && echo ""
-    oc get pod -n cp4waiops | grep ibm-aiops-orchestrator-controller-manager
-    
-    echo ""
+        echo "______________________________________________________________"
+        echo "Orchestrator pod current status:" && echo ""
+        oc get pod -n cp4waiops | grep ibm-aiops-orchestrator-controller-manager
+        
+        echo ""
+    else
+        echo "Sorry, this tool only supports CP4WAIOps v3.3 at this time. 
+
+You currently have your CP4WAIOps version in this script set to \"$CP4WAIOPS_VERSION\". 
+
+If this is incorrect, please update the \`CP4WAIOPS_VERSION\` variable
+in this script to \"3.3\" and run \`oc waiops status\` again.
+"
+    fi
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1,5 +1,27 @@
 #!/bin/bash
-printf "\nNOTE: Please remember to update the PROJECT_NAMESPACE variable in the script (default set to `cp4waiops`) so that it correctly references the namespace where you have. Otherwise you might encounter errors below.\n\n"
+# The CP4WAIOps status checker tool prints out several components to indicate the status of your install.
+# In a successful install, the components below should all have a successful STATUS/PROGRESS/PHASE indicator.
+# If any of the components are incomplete or are not reconciled after a significant period of time, 
+# please refer to the IBM troubleshooting docs online or open a support case. 
+
+echo "
+ __________________________________________________________
+|                                                          |
+|      CLOUD PAK FOR WATSON AIOPS STATUS CHECKER TOOL      |
+|__________________________________________________________|
+|  NOTE: Please remember to update the PROJECT_NAMESPACE   |
+|  variable in the script so that it correctly references  |
+|  your installation namespace.                            |
+|                                                          |
+|  If this is not set correctly, you will see errors in    |
+|  the output of the status checker below.                 |
+|                                                          |
+|  PROJECT_NAMESPACE by default is set to \"cp4waiops\".     |
+|                                                          |
+|  If your install is in a namespace called \"cp4waiops\",   |
+|  then no change to this script is required.              | 
+|__________________________________________________________|
+"
 export PROJECT_NAMESPACE="cp4waiops"
 
 # optional argument handling
@@ -19,21 +41,51 @@ fi
 # optional argument handling
 if [[ "$1" == "status" ]]
 then
-    oc get installations.orchestrator.aiops.ibm.com -A && echo "" &&  oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason" && echo "" && oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
-    echo "" && oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:spec.version,STATUS:.status.conditions[?(@.type=="Ready")].status'
-    echo "" && oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+    echo "______________________________________________________________"
+    echo "Installation instances:" && echo ""
+    oc get installations.orchestrator.aiops.ibm.com -A 
     
-    printf "\nCSVs from $PROJECT_NAMESPACE namespace:"
-    echo "" && oc get csvs -n $PROJECT_NAMESPACE 
+    echo "______________________________________________________________"
+    echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
+    oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
     
-    printf "\nCSVs from ibm-common-services namespace:"
-    echo "" && oc get csvs -n ibm-common-services
+    echo "______________________________________________________________"
+    echo "LifecycleService instances:" && echo ""
+    oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "BaseUI instances:" && echo ""
+    oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "AIManager, AIOpsEdge, and ASM instances:" && echo ""
+    oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
+    
+    echo "______________________________________________________________"
+    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
+    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:spec.version,STATUS:.status.conditions[?(@.type=="Ready")].status'
+    
+    echo "______________________________________________________________"
+    echo "ZenService instances:" && echo ""
+    oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+    
+    echo "______________________________________________________________"
+    echo "CSVs from $PROJECT_NAMESPACE namespace:" && echo ""
+    oc get csvs -n $PROJECT_NAMESPACE 
+ 
+    echo "______________________________________________________________"
+    echo "CSVs from ibm-common-services namespace:" && echo ""
+    oc get csvs -n ibm-common-services
 
-    printf "\nSubscriptions from $PROJECT_NAMESPACE namespace:"
-    echo "" && oc get subscriptions -n $PROJECT_NAMESPACE 
+    echo "______________________________________________________________"
+    echo "Subscriptions from $PROJECT_NAMESPACE namespace:" && echo ""
+    oc get subscriptions -n $PROJECT_NAMESPACE 
+
+    echo "______________________________________________________________"
+    echo "Subscriptions from ibm-common-services namespace:" && echo ""
+    oc get subscriptions -n ibm-common-services 
     
-    printf "\nSubscriptions from ibm-common-services namespace:"
-    echo "" && oc get subscriptions -n ibm-common-services
+    echo ""
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -14,8 +14,8 @@ white=$(tput setaf 7)
 bold=$(tput bold)
 normal=$(tput sgr0) #reset color/bolding
 
-# Get installation namespace (inferred from location of orchestrator pod)
-PROJECT_NAMESPACE=$(oc get pods --all-namespaces|grep ibm-aiops-orchestrator|awk '{print $1}')
+# Get installation namespace (inferred from installation instance)
+PROJECT_NAMESPACE=$(oc get installations.orchestrator.aiops.ibm.com -A --no-headers | while read a b c; do echo "$a"; done;)
 
 # optional argument handling
 if [[ "$1" == "version" ]]

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1,47 +1,29 @@
 #!/bin/bash
+
 # The CP4WAIOps status checker tool prints out several components to indicate the status of your install.
 # In a successful install, the components below should all have a successful STATUS/PROGRESS/PHASE indicator.
 # If any of the components are incomplete or are not reconciled after a significant period of time, 
 # please refer to the IBM troubleshooting docs online or open a support case. 
 
-echo "
- __________________________________________________________
-|                                                          |
-|      CLOUD PAK FOR WATSON AIOPS STATUS CHECKER TOOL      |
-|__________________________________________________________|
-|  NOTE: Please remember to update the PROJECT_NAMESPACE   |
-|  variable in the script so that it correctly references  |
-|  your installation namespace.                            |
-|                                                          |
-|  If this is not set correctly, you will see errors in    |
-|  the output of the status checker below.                 |
-|                                                          |
-|  PROJECT_NAMESPACE by default is set to \"cp4waiops\".     |
-|                                                          |
-|  If your install is in a namespace called \"cp4waiops\",   |
-|  then no change to this script is required.              | 
-|                                                          |
-|  After running the status checker script, if the         |
-|  components listed below have successfully installed,    |
-|  each component's Status/Phase will indicate this in     |
-|  the list below as Completed/Configured/True/etc.        |
-|                                                          |
-|  However, if there are components that are not           |
-|  fully reconciled yet, please refer to their pod logs    |
-|  for more information. If only a short time has passed   |
-|  since the install was started, the components may       |
-|  need more time to complete fully. If you have waited    |
-|  a significant amount of time and the components         |
-|  listed below are not indicating completion or success,  |
-|  please refer to the troubleshooting docs or open        |
-|  a support case.                                         |
-|__________________________________________________________|
-"
-# Please update PROJECT_NAMESPACE below to your installation namespace.
-# By default in this script, this is set to "cp4waiops".
-export PROJECT_NAMESPACE="cp4waiops"
+# Various formatting elements
+newline='\n\n'
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+blue=$(tput setaf 4)
+white=$(tput setaf 7)
+bold=$(tput bold)
+normal=$(tput sgr0) #reset color/bolding
 
 export CP4WAIOPS_VERSION="3.3"
+
+# Get installation namespace
+if [ "$PROJECT_NAMESPACE" == "" ]
+then
+    printf "
+${bold}${blue}Enter your Cloud Pak for Watson AIOps installation namespace: ${normal}"
+    read PROJECT_NAMESPACE
+    oc project ${PROJECT_NAMESPACE}
+fi
 
 # optional argument handling
 if [[ "$1" == "version" ]]
@@ -79,12 +61,18 @@ then
         oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason"
         
         echo "______________________________________________________________"
-        echo "AIManager, AIOpsEdge, and ASM instances:" && echo ""
-        oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
-        
+        echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
+        oc get AIManager,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
+        oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase" && echo ""
+        oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled"
+
         echo "______________________________________________________________"
         echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
         oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status'
+        
+        echo "______________________________________________________________"
+        echo "Kong instances:" && echo ""
+        oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name"         
         
         echo "______________________________________________________________"
         echo "ZenService instances:" && echo ""
@@ -116,7 +104,7 @@ then
 
         echo "______________________________________________________________"
         echo "Orchestrator pod current status:" && echo ""
-        oc get pod -n cp4waiops | grep ibm-aiops-orchestrator-controller-manager
+        oc get pod -n $PROJECT_NAMESPACE | grep ibm-aiops-orchestrator-controller-manager
         
         echo ""
     else
@@ -128,6 +116,154 @@ If this is incorrect, please update the \`CP4WAIOPS_VERSION\` variable
 in this script to \"3.3\" and run \`oc waiops status\` again.
 "
     fi
+    exit 0
+fi
+
+# optional argument handling
+if [[ "$1" == "upgrade-status" ]]
+then
+    # Script to check upgrade status of CP4WAIOps install for v3.3
+    # This script checks to see if your Cloud Pak for Watson AIOps
+    # instance is properly configured post-upgrade for v3.3. 
+
+    FAILING_UPGRADE=""
+    SUCCESSFULLY_UPGRADED=""
+
+    aiopsEdgeBaseUpgradeStatus() {    
+        UPGRADED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.conditions[?(@.type=="UpgradeReady")].status}')
+        DETAILS=$(oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase")
+        if [ "${UPGRADED}" == "True" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    aiopsUIUpgradeStatus() {    
+        CURRENT_MAJOR_VERSION=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
+        DETAILS=$(oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled")
+        if [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    kongUpgradeStatus() {    
+        INITIALIZED=$(oc get kong gateway -o jsonpath='{.status.conditions[?(@.type=="Initialized")].status}')
+        DEPLOYED=$(oc get kong gateway -o jsonpath='{.status.conditions[?(@.type=="Deployed")].status}')
+        DETAILS=$(oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name")
+        if [ "${INITIALIZED}" == "True" ] && [ "${DEPLOYED}" == "True" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    aiManagerUpgradeStatus() {    
+        PHASE_STATUS=$(oc get aimanager aimanager -o jsonpath='{.status.phase}')
+        CURRENT_MAJOR_VERSION=$(oc get aimanager aimanager -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
+        DETAILS=$(oc get aimanager -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase")
+        if [ "${PHASE_STATUS}" == "Completed" ] && [ "${CURRENT_MAJOR_VERSION}" == "2.4" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    irCoreUpgradeStatus() {
+        UPGRADED=$(oc get ircore aiops -o json | jq '.metadata.generation as $generation|[(.status.conditions[]|select(.type=="Ready")|.status == "True" and .observedGeneration == $generation)]|all')
+        CURRENT_MAJOR_VERSION=$(oc get ircore aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
+        DETAILS=$(oc get ircore -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason")
+        if [ "${UPGRADED}" == true ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    lifecycleUpgradeStatus() {
+        UPGRADED=$(oc get lifecycleservices aiops -o json | jq '.metadata.generation as $generation|[(.status.conditions[]|select(.type=="Ready")|.status == "True"), (.status.observedGeneration == $generation)]|all')
+        CURRENT_MAJOR_VERSION=$(oc get lifecycleservices aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
+        DETAILS=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason")
+        if [ "${UPGRADED}" == true ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    aiopsAnalyticsUpgradeStatus() {
+        UPGRADED=$(oc get AIOpsAnalyticsOrchestrator aiops -o json | jq '.metadata.generation as $generation|[(.status.conditions[]|select(.type=="Ready")|.status == "True" and .observedGeneration == $generation)]|all')
+        CURRENT_MAJOR_VERSION=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
+        DETAILS=$(oc get AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason")
+        if [ "${UPGRADED}" == true ] && [ "${CURRENT_MAJOR_VERSION}" == "3.2" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
+    # Run component status checks
+    aiopsEdgeBaseUpgradeStatus
+    lifecycleUpgradeStatus
+    aiopsUIUpgradeStatus
+    kongUpgradeStatus
+    aiManagerUpgradeStatus
+    irCoreUpgradeStatus
+    aiopsAnalyticsUpgradeStatus
+
+    # Print out results of status checks
+    printf "
+${bold}${green}______________________________________________________________
+
+The following component(s) have finished upgrading:
+${normal}${SUCCESSFULLY_UPGRADED}
+
+${bold}${green}______________________________________________________________
+"
+    if [ "$FAILING_UPGRADE" != "" ];
+    then 
+        printf "
+${bold}${red}______________________________________________________________
+
+Meanwhile, the following component(s) have not upgraded yet:
+${normal}${FAILING_UPGRADE}
+
+If only a short time has passed since the upgrade was started, the components may
+need more time to complete upgrading. If you have waited a significant amount of time
+and the statuses of the components listed below are not changing, please refer to
+the troubleshooting docs or open a support case.
+
+${bold}${red}______________________________________________________________
+";
+    fi
+
+    printf "
+${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status\`.
+${normal}
+"
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1,5 +1,5 @@
 #!/bin/bash
-printf "NOTE: Please remember to update the PROJECT_NAMESPACE variable in the script so that it correctly references the namespace where you have"
+printf "\nNOTE: Please remember to update the PROJECT_NAMESPACE variable in the script (default set to `cp4waiops`) so that it correctly references the namespace where you have. Otherwise you might encounter errors below.\n\n"
 export PROJECT_NAMESPACE="cp4waiops"
 
 # optional argument handling
@@ -20,7 +20,7 @@ fi
 if [[ "$1" == "status" ]]
 then
     oc get installations.orchestrator.aiops.ibm.com -A && echo "" &&  oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason" && echo "" && oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
-    echo "" && oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.conditions[?(@.type=="Ready")].status'
+    echo "" && oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:spec.version,STATUS:.status.conditions[?(@.type=="Ready")].status'
     echo "" && oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
     
     printf "\nCSVs from $PROJECT_NAMESPACE namespace:"

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1,4 +1,7 @@
 #!/bin/bash
+printf "NOTE: Please remember to update the PROJECT_NAMESPACE variable in the script so that it correctly references the namespace where you have"
+export PROJECT_NAMESPACE="cp4waiops"
+
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
@@ -16,9 +19,21 @@ fi
 # optional argument handling
 if [[ "$1" == "status" ]]
 then
-    oc get installations.orchestrator.aiops.ibm.com -A && echo "" &&  oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get lifecycleservice -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason" && echo "" && oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase"
+    oc get installations.orchestrator.aiops.ibm.com -A && echo "" &&  oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason" && echo "" && oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason" && echo "" && oc get AIManager,aiopsedge,asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase"
     echo "" && oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.conditions[?(@.type=="Ready")].status'
     echo "" && oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+    
+    printf "\nCSVs from $PROJECT_NAMESPACE namespace:"
+    echo "" && oc get csvs -n $PROJECT_NAMESPACE 
+    
+    printf "\nCSVs from ibm-common-services namespace:"
+    echo "" && oc get csvs -n ibm-common-services
+
+    printf "\nSubscriptions from $PROJECT_NAMESPACE namespace:"
+    echo "" && oc get subscriptions -n $PROJECT_NAMESPACE 
+    
+    printf "\nSubscriptions from ibm-common-services namespace:"
+    echo "" && oc get subscriptions -n ibm-common-services
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -99,7 +99,11 @@ then
     echo "______________________________________________________________"
     echo "Subscriptions from ibm-common-services namespace:" && echo ""
     oc get subscriptions -n ibm-common-services
-
+    
+    echo "______________________________________________________________"
+    echo "OperandRequest instances:" && echo ""
+    oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp"
+    
     echo "______________________________________________________________"
     echo "ODLM pod current status:" && echo ""
     oc get pod -n ibm-common-services | grep operand-deployment-lifecycle-manager

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -20,7 +20,7 @@ PROJECT_NAMESPACE=$(oc get pods --all-namespaces|grep ibm-aiops-orchestrator|awk
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.2"
+    echo "0.0.3"
     exit 0
 fi
 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -199,9 +199,5 @@ Verify plugin:
 git clone https://github.com/IBM/cp4waiops-samples.git
 chmod +x cp4waiops-samples/kubectl-plugin/kubectl-waiops
 cp cp4waiops-samples/kubectl-plugin/kubectl-waiops /usr/local/bin/kubectl-waiops
-```
-
-Once you have done the above, you can run the following commands to use the status checker tool: 
-```
 oc waiops status 
 ```

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -6,181 +6,228 @@ https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
 
 ## Highlights
 
+### Main status checker
 ```
 $ oc waiops status
- __________________________________________________________
-|                                                          |
-|      CLOUD PAK FOR WATSON AIOPS STATUS CHECKER TOOL      |
-|__________________________________________________________|
-|  NOTE: Please remember to update the PROJECT_NAMESPACE   |
-|  variable in the script so that it correctly references  |
-|  your installation namespace.                            |
-|                                                          |
-|  If this is not set correctly, you will see errors in    |
-|  the output of the status checker below.                 |
-|                                                          |
-|  PROJECT_NAMESPACE by default is set to "cp4waiops".     |
-|                                                          |
-|  If your install is in a namespace called "cp4waiops",   |
-|  then no change to this script is required.              | 
-|__________________________________________________________|
 
 ______________________________________________________________
 Installation instances:
 
-NAMESPACE   NAME                  PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
-cp4waiops   ibm-cp-watson-aiops   Running   Accepted   rook-cephfs    rook-ceph-block          8d
+NAMESPACE   NAME                 PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
+katamari    aiops-installation   Running   Accepted   rook-cephfs    rook-cephfs              4h54m
 ______________________________________________________________
 IRCore and AIOpsAnalyticsOrchestrator instances:
 
 KIND                         NAMESPACE   NAME    VERSION   STATUS
-IssueResolutionCore          cp4waiops   aiops   3.2.1     Ready
-AIOpsAnalyticsOrchestrator   cp4waiops   aiops   3.2.0     Ready
+IssueResolutionCore          katamari    aiops   3.4.0     Ready
+AIOpsAnalyticsOrchestrator   katamari    aiops   3.2.0     Ready
 ______________________________________________________________
 LifecycleService instances:
 
 KIND               NAMESPACE   NAME    VERSION   STATUS
-LifecycleService   cp4waiops   aiops   3.3.0     Ready
+LifecycleService   katamari    aiops   3.4.0     Ready
 ______________________________________________________________
 BaseUI instances:
 
 KIND     NAMESPACE   NAME              VERSION   STATUS
-BaseUI   cp4waiops   baseui-instance   3.3.0     Ready
+BaseUI   katamari    baseui-instance   0.1.0     Ready
 ______________________________________________________________
-AIManager, AIOpsEdge, and ASM instances:
+AIManager, ASM, AIOpsEdge, and AIOpsUI instances:
 
 KIND        NAMESPACE   NAME             VERSION   STATUS
-AIManager   cp4waiops   aimanager        2.4.0     Completed
-AIOpsEdge   cp4waiops   aiopsedge        <none>    Configured
-ASM         cp4waiops   aiops-topology   2.2.0     OK
+AIManager   katamari    aimanager        2.4.0     Completed
+ASM         katamari    aiops-topology   2.2.0     OK
+
+KIND        NAMESPACE   NAME        STATUS
+AIOpsEdge   katamari    aiopsedge   Configured
+
+KIND      NAMESPACE   NAME               VERSION
+AIOpsUI   katamari    aiopsui-instance   0.1.0
 ______________________________________________________________
 AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
 
 KIND                    NAMESPACE   NAME                    VERSION   STATUS
-AutomationUIConfig      cp4waiops   iaf-system              v1.3      True
-AutomationBase          cp4waiops   automationbase-sample   v2.0      True
-Cartridge               cp4waiops   cp4waiops-cartridge     v1.3      True
-CartridgeRequirements   cp4waiops   cp4waiops-cartridge     v1.3      True
+AutomationUIConfig      katamari    iaf-system              1.3.3     True
+AutomationBase          katamari    automationbase-sample   2.0.3     True
+Cartridge               katamari    cp4waiops-cartridge     1.3.3     True
+CartridgeRequirements   katamari    cp4waiops-cartridge     1.3.3     True
+______________________________________________________________
+Kong instances:
+
+KIND   NAMESPACE   NAME
+Kong   katamari    gateway
 ______________________________________________________________
 ZenService instances:
 
 KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
-ZenService   iaf-zen-cpdservice   cp4waiops   4.4.1     Completed   100%       The Current Operation Is Completed
+ZenService   iaf-zen-cpdservice   katamari    4.4.3     Completed   100%       The Current Operation Is Completed
 ______________________________________________________________
-CSVs from cp4waiops namespace:
+CSVs from katamari namespace:
 
 NAME                                               DISPLAY                                            VERSION              REPLACES                                PHASE
-aimanager-operator.v3.3.0-202203130801             IBM Watson AIOps AI Manager                        3.3.0-202203130801   aimanager-operator.v3.2.1               Succeeded
-aiopsedge-operator.v3.3.0-202203130801             IBM Watson AIOps Edge                              3.3.0-202203130801   aiopsedge-operator.v3.2.1               Succeeded
-asm-operator.v3.3.0-202203130801                   IBM Netcool Agile Service Manager                  3.3.0-202203130801   asm-operator.v3.2.1                     Succeeded
+aimanager-operator.v0.1.0-202203281601             IBM Watson AIOps AI Manager                        0.1.0-202203281601                                           Succeeded
+aiopsedge-operator.v0.1.0-202203281601             IBM Watson AIOps Edge                              0.1.0-202203281601                                           Succeeded
+asm-operator.v0.1.0-202203281601                   IBM Netcool Agile Service Manager                  0.1.0-202203281601                                           Succeeded
 couchdb-operator.v2.2.1                            Operator for Apache CouchDB                        2.2.1                couchdb-operator.v2.2.0                 Succeeded
-ibm-aiops-ir-ai.v3.3.0-202203130801                IBM Watson AIOps Issue Resolution AI & Analytics   3.3.0-202203130801   ibm-aiops-ir-ai.v3.2.1                  Succeeded
-ibm-aiops-ir-core.v3.3.0-202203130801              IBM Watson AIOps Issue Resolution Core             3.3.0-202203130801   ibm-aiops-ir-core.v3.2.1                Succeeded
-ibm-aiops-ir-lifecycle.v3.3.0-202203130801         IBM Cloud Pak for Watson AIOps Lifecycle           3.3.0-202203130801   ibm-aiops-ir-lifecycle.v3.2.1           Succeeded
-ibm-aiops-orchestrator.v3.3.0-202203130801         IBM Cloud Pak for Watson AIOps AI Manager          3.3.0-202203130801   ibm-aiops-orchestrator.v3.2.1           Succeeded
-ibm-automation-core.v1.3.4                         IBM Automation Foundation Core                     1.3.4                ibm-automation-core.v1.3.3              Succeeded
-ibm-automation-elastic.v1.3.3                      IBM Elastic                                        1.3.3                ibm-automation-elastic.v1.3.2           Succeeded
-ibm-automation-eventprocessing.v1.3.4              IBM Automation Foundation Event Processing         1.3.4                ibm-automation-eventprocessing.v1.3.3   Succeeded
-ibm-automation-flink.v1.3.3                        IBM Automation Foundation Flink                    1.3.3                ibm-automation-flink.v1.3.2             Succeeded
-ibm-automation.v1.3.4                              IBM Automation Foundation                          1.3.4                ibm-automation.v1.3.3                   Succeeded
-ibm-cloud-databases-redis.v1.4.3                   IBM Operator for Redis                             1.4.3                ibm-cloud-databases-redis.v1.3.3        Succeeded
-ibm-common-service-operator.v3.16.1                IBM Cloud Pak foundational services                3.16.1               ibm-common-service-operator.v3.15.1     Succeeded
-ibm-management-kong.v3.3.0-202203130801            IBM Internal - IBM Watson AIOps Kong               3.3.0-202203130801   ibm-management-kong.v3.2.1              Succeeded
-ibm-postgreservice-operator.v3.3.0-202203130801    IBM Postgreservice                                 3.3.0-202203130801   ibm-postgreservice-operator.v3.2.1      Succeeded
-ibm-vault-operator.v3.3.0-202203130801             IBM Vault Operator                                 3.3.0-202203130801   ibm-vault-operator.v3.2.1               Succeeded
-ibm-watson-aiops-ui-operator.v3.3.0-202203130801   IBM Watson AIOps UI                                3.3.0-202203130801   ibm-watson-aiops-ui-operator.v3.2.1     Succeeded
+elasticsearch-operator.5.3.5-20                    OpenShift Elasticsearch Operator                   5.3.5-20                                                     Succeeded
+ibm-aiops-ir-ai.v0.1.0-202203281601                IBM Watson AIOps Issue Resolution AI & Analytics   0.1.0-202203281601                                           Succeeded
+ibm-aiops-ir-core.v0.1.0-202203281601              IBM Watson AIOps Issue Resolution Core             0.1.0-202203281601                                           Succeeded
+ibm-aiops-ir-lifecycle.v0.1.0-202203281601         IBM Cloud Pak for Watson AIOps Lifecycle           0.1.0-202203281601                                           Succeeded
+ibm-aiops-orchestrator.v0.1.0-202203281601         IBM Cloud Pak for Watson AIOps AI Manager          0.1.0-202203281601                                           Succeeded
+ibm-automation-core.v1.3.5                         IBM Automation Foundation Core                     1.3.5                ibm-automation-core.v1.3.4              Succeeded
+ibm-automation-elastic.v1.3.4                      IBM Elastic                                        1.3.4                ibm-automation-elastic.v1.3.3           Succeeded
+ibm-automation-eventprocessing.v1.3.5              IBM Automation Foundation Event Processing         1.3.5                ibm-automation-eventprocessing.v1.3.4   Succeeded
+ibm-automation-flink.v1.3.4                        IBM Automation Foundation Flink                    1.3.4                ibm-automation-flink.v1.3.3             Succeeded
+ibm-automation.v1.3.5                              IBM Automation Foundation                          1.3.5                ibm-automation.v1.3.4                   Succeeded
+ibm-cloud-databases-redis.v1.4.3                   IBM Operator for Redis                             1.4.3                ibm-cloud-databases-redis.v1.4.2        Succeeded
+ibm-common-service-operator.v3.17.0                IBM Cloud Pak foundational services                3.17.0               ibm-common-service-operator.v3.16.1     Succeeded
+ibm-management-kong.v0.1.0-202203281601            IBM Internal - IBM Watson AIOps Kong               0.1.0-202203281601                                           Succeeded
+ibm-postgreservice-operator.v0.1.0-202203281601    IBM Postgreservice                                 0.1.0-202203281601                                           Succeeded
+ibm-secure-tunnel-operator.v0.1.0-202203281601     IBM Secure Tunnel                                  0.1.0-202203281601                                           Succeeded
+ibm-vault-operator.v0.1.0-202203281601             IBM Vault Operator                                 0.1.0-202203281601                                           Succeeded
+ibm-watson-aiops-ui-operator.v0.1.0-202203281601   IBM Watson AIOps UI                                0.1.0-202203281601                                           Succeeded
 ______________________________________________________________
 CSVs from ibm-common-services namespace:
 
-NAME                                                 DISPLAY                                VERSION   REPLACES                                       PHASE
-ibm-cert-manager-operator.v3.18.1                    IBM Cert Manager                       3.18.1    ibm-cert-manager-operator.v3.17.0              Succeeded
-ibm-common-service-operator.v3.16.1                  IBM Cloud Pak foundational services    3.16.1    ibm-common-service-operator.v3.15.1            Succeeded
-ibm-commonui-operator.v1.14.0                        Ibm Common UI                          1.14.0    ibm-commonui-operator.v1.13.0                  Succeeded
-ibm-crossplane-operator.v1.5.0                       IBM Crossplane                         1.5.0     ibm-crossplane-operator.v1.4.1                 Succeeded
-ibm-crossplane-provider-kubernetes-operator.v1.5.0   IBM Crossplane Provider Kubernetes     1.5.0                                                    Succeeded
-ibm-events-operator.v3.15.0                          IBM Events Operator                    3.15.0    ibm-events-operator.v3.14.2                    Succeeded
-ibm-iam-operator.v3.16.0                             IBM IAM Operator                       3.16.0    ibm-iam-operator.v3.13.0                       Succeeded
-ibm-ingress-nginx-operator.v1.13.0                   IBM Ingress Nginx Operator             1.13.0    ibm-ingress-nginx-operator.v1.12.0             Succeeded
-ibm-licensing-operator.v1.13.0                       IBM Licensing Operator                 1.13.0    ibm-licensing-operator.v1.12.0                 Succeeded
-ibm-management-ingress-operator.v1.13.0              Management Ingress Operator            1.13.0    ibm-management-ingress-operator.v1.12.0        Succeeded
-ibm-mongodb-operator.v1.11.0                         IBM MongoDB Operator                   1.11.0    ibm-mongodb-operator.v1.10.0                   Succeeded
-ibm-namespace-scope-operator.v1.10.0                 IBM NamespaceScope Operator            1.10.0    ibm-namespace-scope-operator.v1.9.0            Succeeded
-ibm-platform-api-operator.v3.18.0                    IBM Platform API                       3.18.0    ibm-platform-api-operator.v3.17.0              Succeeded
-ibm-zen-operator.v1.5.1                              IBM Zen Service                        1.5.1     ibm-zen-operator.v1.5.0                        Succeeded
-operand-deployment-lifecycle-manager.v1.14.0         Operand Deployment Lifecycle Manager   1.14.0    operand-deployment-lifecycle-manager.v1.13.0   Succeeded
+NAME                                                 DISPLAY                                VERSION    REPLACES                                       PHASE
+elasticsearch-operator.5.3.5-20                      OpenShift Elasticsearch Operator       5.3.5-20                                                  Succeeded
+ibm-cert-manager-operator.v3.19.0                    IBM Cert Manager                       3.19.0     ibm-cert-manager-operator.v3.18.1              Succeeded
+ibm-common-service-operator.v3.17.0                  IBM Cloud Pak foundational services    3.17.0     ibm-common-service-operator.v3.16.1            Succeeded
+ibm-commonui-operator.v1.15.0                        Ibm Common UI                          1.15.0     ibm-commonui-operator.v1.14.0                  Succeeded
+ibm-crossplane-operator.v1.6.0                       IBM Crossplane                         1.6.0      ibm-crossplane-operator.v1.5.0                 Succeeded
+ibm-crossplane-provider-kubernetes-operator.v1.6.0   IBM Crossplane Provider Kubernetes     1.6.0                                                     Succeeded
+ibm-events-operator.v3.15.0                          IBM Events Operator                    3.15.0     ibm-events-operator.v3.14.2                    Succeeded
+ibm-iam-operator.v3.17.0                             IBM IAM Operator                       3.17.0     ibm-iam-operator.v3.16.0                       Succeeded
+ibm-ingress-nginx-operator.v1.14.0                   IBM Ingress Nginx Operator             1.14.0     ibm-ingress-nginx-operator.v1.13.0             Succeeded
+ibm-licensing-operator.v1.14.0                       IBM Licensing Operator                 1.14.0     ibm-licensing-operator.v1.13.0                 Succeeded
+ibm-management-ingress-operator.v1.14.0              Management Ingress Operator            1.14.0     ibm-management-ingress-operator.v1.12.0        Succeeded
+ibm-mongodb-operator.v1.12.0                         IBM MongoDB Operator                   1.12.0     ibm-mongodb-operator.v1.11.0                   Succeeded
+ibm-namespace-scope-operator.v1.11.0                 IBM NamespaceScope Operator            1.11.0     ibm-namespace-scope-operator.v1.10.0           Succeeded
+ibm-platform-api-operator.v3.19.0                    IBM Platform API                       3.19.0     ibm-platform-api-operator.v3.18.0              Succeeded
+ibm-zen-operator.v1.5.3                              IBM Zen Service                        1.5.3      ibm-zen-operator.v1.5.2                        Succeeded
+operand-deployment-lifecycle-manager.v1.15.0         Operand Deployment Lifecycle Manager   1.15.0     operand-deployment-lifecycle-manager.v1.14.0   Succeeded
 ______________________________________________________________
-Subscriptions from cp4waiops namespace:
+Subscriptions from katamari namespace:
 
-NAME                                                                              PACKAGE                              SOURCE                  CHANNEL
-aimanager-operator                                                                aimanager-operator                   ibm-cp-waiops-catalog   3.3-dev
-aiopsedge-operator                                                                aiopsedge-operator                   ibm-cp-waiops-catalog   3.3-dev
-asm-operator                                                                      asm-operator                         ibm-cp-waiops-catalog   3.3-dev
-couchdb                                                                           couchdb-operator                     ibm-cp-waiops-catalog   v2.2
-ibm-aiops-orchestrator                                                            ibm-aiops-orchestrator               ibm-cp-waiops-catalog   3.3-dev
-ibm-automation-core-v1.3-ibm-cp-waiops-catalog-openshift-marketplace              ibm-automation-core                  ibm-cp-waiops-catalog   v1.3
-ibm-automation-elastic-v1.3-ibm-cp-waiops-catalog-openshift-marketplace           ibm-automation-elastic               ibm-cp-waiops-catalog   v1.3
-ibm-automation-eventprocessing-v1.3-ibm-cp-waiops-catalog-openshift-marketplace   ibm-automation-eventprocessing       ibm-cp-waiops-catalog   v1.3
-ibm-automation-flink-v1.3-ibm-cp-waiops-catalog-openshift-marketplace             ibm-automation-flink                 ibm-cp-waiops-catalog   v1.3
-ibm-automation-v1.3-ibm-cp-waiops-catalog-openshift-marketplace                   ibm-automation                       ibm-cp-waiops-catalog   v1.3
-ibm-common-service-operator-v3-ibm-cp-waiops-catalog-openshift-marketplace        ibm-common-service-operator          ibm-cp-waiops-catalog   v3
-ibm-management-kong                                                               ibm-management-kong                  ibm-cp-waiops-catalog   3.3-dev
-ibm-postgreservice-operator                                                       ibm-postgreservice-operator          ibm-cp-waiops-catalog   3.3-dev
-ibm-watson-aiops-ui-operator                                                      ibm-watson-aiops-ui-operator         ibm-cp-waiops-catalog   3.3-dev
-ir-ai-operator                                                                    ibm-aiops-ir-ai                      ibm-cp-waiops-catalog   3.3-dev
-ir-core-operator                                                                  ibm-aiops-ir-core                    ibm-cp-waiops-catalog   3.3-dev
-ir-lifecycle-operator                                                             ibm-aiops-ir-lifecycle               ibm-cp-waiops-catalog   3.3-dev
-redis                                                                             ibm-cloud-databases-redis-operator   ibm-cp-waiops-catalog   v1.4
-vault                                                                             ibm-vault-operator                   ibm-cp-waiops-catalog   3.3-dev
+NAME                                                                       PACKAGE                              SOURCE                  CHANNEL
+aimanager-operator                                                         aimanager-operator                   ibm-cp-waiops-catalog   0.1-dev
+aiopsedge-operator                                                         aiopsedge-operator                   ibm-cp-waiops-catalog   0.1-dev
+asm-operator                                                               asm-operator                         ibm-cp-waiops-catalog   0.1-dev
+couchdb                                                                    couchdb-operator                     ibm-cp-waiops-catalog   v2.2
+ibm-aiops-orchestrator                                                     ibm-aiops-orchestrator               ibm-cp-waiops-catalog   0.1-dev
+ibm-automation                                                             ibm-automation                       iaf-operators           v1.3
+ibm-automation-core-v1.3-iaf-core-operators-openshift-marketplace          ibm-automation-core                  iaf-core-operators      v1.3
+ibm-automation-elastic-v1.3-iaf-operators-openshift-marketplace            ibm-automation-elastic               iaf-operators           v1.3
+ibm-automation-eventprocessing-v1.3-iaf-operators-openshift-marketplace    ibm-automation-eventprocessing       iaf-operators           v1.3
+ibm-automation-flink-v1.3-iaf-operators-openshift-marketplace              ibm-automation-flink                 iaf-operators           v1.3
+ibm-common-service-operator-v3-opencloud-operators-openshift-marketplace   ibm-common-service-operator          opencloud-operators     v3
+ibm-management-kong                                                        ibm-management-kong                  ibm-cp-waiops-catalog   0.1-dev
+ibm-postgreservice-operator                                                ibm-postgreservice-operator          ibm-cp-waiops-catalog   0.1-dev
+ibm-secure-tunnel-operator                                                 ibm-secure-tunnel-operator           ibm-cp-waiops-catalog   0.1-dev
+ibm-watson-aiops-ui-operator                                               ibm-watson-aiops-ui-operator         ibm-cp-waiops-catalog   0.1-dev
+ir-ai-operator                                                             ibm-aiops-ir-ai                      ibm-cp-waiops-catalog   0.1-dev
+ir-core-operator                                                           ibm-aiops-ir-core                    ibm-cp-waiops-catalog   0.1-dev
+ir-lifecycle-operator                                                      ibm-aiops-ir-lifecycle               ibm-cp-waiops-catalog   0.1-dev
+redis                                                                      ibm-cloud-databases-redis-operator   ibm-cp-waiops-catalog   v1.4
+vault                                                                      ibm-vault-operator                   ibm-cp-waiops-catalog   0.1-dev
 ______________________________________________________________
 Subscriptions from ibm-common-services namespace:
 
-NAME                                              PACKAGE                                           SOURCE                  CHANNEL
-ibm-cert-manager-operator                         ibm-cert-manager-operator                         ibm-cp-waiops-catalog   v3
-ibm-common-service-operator                       ibm-common-service-operator                       ibm-cp-waiops-catalog   v3
-ibm-commonui-operator                             ibm-commonui-operator-app                         ibm-cp-waiops-catalog   v3
-ibm-crossplane-operator-app                       ibm-crossplane-operator-app                       ibm-cp-waiops-catalog   v3
-ibm-crossplane-provider-kubernetes-operator-app   ibm-crossplane-provider-kubernetes-operator-app   ibm-cp-waiops-catalog   v3
-ibm-events-operator                               ibm-events-operator                               ibm-cp-waiops-catalog   v3
-ibm-iam-operator                                  ibm-iam-operator                                  ibm-cp-waiops-catalog   v3
-ibm-ingress-nginx-operator                        ibm-ingress-nginx-operator-app                    ibm-cp-waiops-catalog   v3
-ibm-licensing-operator                            ibm-licensing-operator-app                        ibm-cp-waiops-catalog   v3
-ibm-management-ingress-operator                   ibm-management-ingress-operator-app               ibm-cp-waiops-catalog   v3
-ibm-mongodb-operator                              ibm-mongodb-operator-app                          ibm-cp-waiops-catalog   v3
-ibm-namespace-scope-operator                      ibm-namespace-scope-operator                      ibm-cp-waiops-catalog   v3
-ibm-platform-api-operator                         ibm-platform-api-operator-app                     ibm-cp-waiops-catalog   v3
-ibm-zen-operator                                  ibm-zen-operator                                  ibm-cp-waiops-catalog   v3
-operand-deployment-lifecycle-manager-app          ibm-odlm                                          ibm-cp-waiops-catalog   v3
+NAME                                              PACKAGE                                           SOURCE                CHANNEL
+ibm-cert-manager-operator                         ibm-cert-manager-operator                         opencloud-operators   v3
+ibm-common-service-operator                       ibm-common-service-operator                       opencloud-operators   v3
+ibm-commonui-operator                             ibm-commonui-operator-app                         opencloud-operators   v3
+ibm-crossplane-operator-app                       ibm-crossplane-operator-app                       opencloud-operators   v3
+ibm-crossplane-provider-kubernetes-operator-app   ibm-crossplane-provider-kubernetes-operator-app   opencloud-operators   v3
+ibm-events-operator                               ibm-events-operator                               opencloud-operators   v3
+ibm-iam-operator                                  ibm-iam-operator                                  opencloud-operators   v3
+ibm-ingress-nginx-operator                        ibm-ingress-nginx-operator-app                    opencloud-operators   v3
+ibm-licensing-operator                            ibm-licensing-operator-app                        opencloud-operators   v3
+ibm-management-ingress-operator                   ibm-management-ingress-operator-app               opencloud-operators   v3
+ibm-mongodb-operator                              ibm-mongodb-operator-app                          opencloud-operators   v3
+ibm-namespace-scope-operator                      ibm-namespace-scope-operator                      opencloud-operators   v3
+ibm-platform-api-operator                         ibm-platform-api-operator-app                     opencloud-operators   v3
+ibm-zen-operator                                  ibm-zen-operator                                  opencloud-operators   v3
+operand-deployment-lifecycle-manager-app          ibm-odlm                                          opencloud-operators   v3
 ______________________________________________________________
 OperandRequest instances:
 
 NAMESPACE             NAME                                  PHASE     CREATED AT
-cp4waiops             aiopsedge-base                        Running   2022-03-14T16:23:01Z
-cp4waiops             aiopsedge-cs                          Running   2022-03-14T16:23:01Z
-cp4waiops             iaf-core-operator                     Running   2022-03-14T15:58:24Z
-cp4waiops             iaf-eventprocessing-operator          Running   2022-03-14T15:58:24Z
-cp4waiops             iaf-operator                          Running   2022-03-14T15:58:25Z
-cp4waiops             iaf-system                            Running   2022-03-14T17:45:55Z
-cp4waiops             iaf-system-common-service             Running   2022-03-14T16:20:45Z
-cp4waiops             iaf-system-events                     Running   2022-03-14T16:20:45Z
-cp4waiops             ibm-aiops-ai-manager                  Running   2022-03-14T16:20:40Z
-cp4waiops             ibm-aiops-aiops-foundation            Running   2022-03-14T16:20:40Z
-cp4waiops             ibm-aiops-application-manager         Running   2022-03-14T16:20:40Z
-cp4waiops             ibm-elastic-operator                  Running   2022-03-14T15:58:24Z
-cp4waiops             ibm-iam-service                       Running   2022-03-14T16:42:40Z
-cp4waiops             operandrequest-kafkauser-iaf-system   Running   2022-03-14T17:45:48Z
-ibm-common-services   ibm-commonui-request                  Running   2022-03-14T16:21:14Z
-ibm-common-services   ibm-iam-request                       Running   2022-03-14T16:21:19Z
-ibm-common-services   ibm-mongodb-request                   Running   2022-03-14T16:22:30Z
-ibm-common-services   management-ingress                    Running   2022-03-14T16:22:30Z
-ibm-common-services   platform-api-request                  Running   2022-03-14T16:22:30Z
+ibm-common-services   ibm-commonui-request                  Running   2022-03-28T21:24:19Z
+ibm-common-services   ibm-iam-request                       Running   2022-03-28T21:24:20Z
+ibm-common-services   ibm-mongodb-request                   Running   2022-03-28T21:25:29Z
+ibm-common-services   management-ingress                    Running   2022-03-28T21:25:29Z
+ibm-common-services   platform-api-request                  Running   2022-03-28T21:25:29Z
+katamari              aiopsedge-base                        Running   2022-03-28T21:25:53Z
+katamari              aiopsedge-cs                          Running   2022-03-28T21:25:53Z
+katamari              iaf-core-operator                     Running   2022-03-28T21:21:30Z
+katamari              iaf-eventprocessing-operator          Running   2022-03-28T21:21:23Z
+katamari              iaf-operator                          Running   2022-03-28T21:21:22Z
+katamari              iaf-system                            Running   2022-03-28T21:29:49Z
+katamari              iaf-system-common-service             Running   2022-03-28T21:24:16Z
+katamari              ibm-aiops-ai-manager                  Running   2022-03-28T21:23:42Z
+katamari              ibm-aiops-aiops-foundation            Running   2022-03-28T21:23:42Z
+katamari              ibm-aiops-application-manager         Running   2022-03-28T21:23:42Z
+katamari              ibm-aiops-connection                  Running   2022-03-28T21:23:42Z
+katamari              ibm-elastic-operator                  Running   2022-03-28T21:21:33Z
+katamari              ibm-iam-service                       Running   2022-03-28T21:39:37Z
+katamari              operandrequest-kafkauser-iaf-system   Running   2022-03-28T21:46:59Z
 ______________________________________________________________
 ODLM pod current status:
 
-operand-deployment-lifecycle-manager-86599c9b7f-jx9h7            1/1     Running     0          7d7h
+operand-deployment-lifecycle-manager-79b789fd56-gkdd4           1/1     Running     0               4h55m
 ______________________________________________________________
 Orchestrator pod current status:
 
-ibm-aiops-orchestrator-controller-manager-768877589d-r7kmb        1/1     Running                 0          8d
+ibm-aiops-orchestrator-controller-manager-5787df5997-sz87g        1/1     Running            0                4h55m
+```
+
+### Status checker for upgrade scenario:
+```
+$ oc waiops upgrade-status
+Enter your Cloud Pak for Watson AIOps installation namespace: katamari
+
+______________________________________________________________
+
+The following component(s) have finished upgrading:
+
+
+KIND        NAMESPACE   NAME        STATUS
+AIOpsEdge   katamari    aiopsedge   Configured
+
+KIND   NAMESPACE   NAME
+Kong   katamari    gateway
+
+KIND        NAMESPACE   NAME        VERSION   STATUS
+AIManager   katamari    aimanager   2.4.0     Completed
+
+KIND                         NAMESPACE   NAME    VERSION   STATUS
+AIOpsAnalyticsOrchestrator   katamari    aiops   3.2.0     Ready
+
+______________________________________________________________
+
+______________________________________________________________
+
+Meanwhile, the following component(s) have not upgraded yet:
+
+
+KIND               NAMESPACE   NAME    VERSION   STATUS
+LifecycleService   katamari    aiops   3.4.0     Ready
+
+KIND      NAMESPACE   NAME               VERSION
+AIOpsUI   katamari    aiopsui-instance   0.1.0
+
+KIND                  NAMESPACE   NAME    VERSION   STATUS
+IssueResolutionCore   katamari    aiops   3.4.0     Ready
+
+If only a short time has passed since the upgrade was started, the components may
+need more time to complete upgrading. If you have waited a significant amount of time
+and the statuses of the components listed below are not changing, please refer to
+the troubleshooting docs or open a support case.
+
+______________________________________________________________
+
+Hint: for a more detailed printout of each operator's components' statuses, run `oc waiops status`.
 ```
 
 ## How to use
@@ -202,15 +249,8 @@ chmod +x cp4waiops-samples/kubectl-plugin/kubectl-waiops
 cp cp4waiops-samples/kubectl-plugin/kubectl-waiops /usr/local/bin/kubectl-waiops
 ```
 
-Once you have done the above, make sure that your installation namespace is defined in the script.
-By default in the script, `PROJECT_NAMESPACE` is set to `cp4waiops`. If you have a different
-installation namespace name, please define the below variable with your namespace before proceeding:
-
+Once you have done the above, you can run the following commands to use the status checker tool: 
 ```
-export PROJECT_NAMESPACE="<your installation namespace>"
-```
-
-Once you have done the above, you can run the following command to use the status checker tool: 
-```
-oc waiops status
+oc waiops status 
+oc waiops upgrade-status
 ```

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -185,6 +185,7 @@ ibm-aiops-orchestrator-controller-manager-5787df5997-sz87g        1/1     Runnin
 ### Status checker for upgrade scenario:
 ```
 $ oc waiops upgrade-status
+
 Enter your Cloud Pak for Watson AIOps installation namespace: katamari
 
 ______________________________________________________________

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -150,6 +150,14 @@ ibm-namespace-scope-operator                      ibm-namespace-scope-operator  
 ibm-platform-api-operator                         ibm-platform-api-operator-app                     ibm-cp-waiops-catalog   v3
 ibm-zen-operator                                  ibm-zen-operator                                  ibm-cp-waiops-catalog   v3
 operand-deployment-lifecycle-manager-app          ibm-odlm                                          ibm-cp-waiops-catalog   v3
+______________________________________________________________
+ODLM pod current status:
+
+operand-deployment-lifecycle-manager-86599c9b7f-jx9h7            1/1     Running     0          7d7h
+______________________________________________________________
+Orchestrator pod current status:
+
+ibm-aiops-orchestrator-controller-manager-768877589d-r7kmb        1/1     Running                 0          8d
 ```
 
 ## How to use

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -8,33 +8,148 @@ https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
 
 ```
 $ oc waiops status
+ __________________________________________________________
+|                                                          |
+|      CLOUD PAK FOR WATSON AIOPS STATUS CHECKER TOOL      |
+|__________________________________________________________|
+|  NOTE: Please remember to update the PROJECT_NAMESPACE   |
+|  variable in the script so that it correctly references  |
+|  your installation namespace.                            |
+|                                                          |
+|  If this is not set correctly, you will see errors in    |
+|  the output of the status checker below.                 |
+|                                                          |
+|  PROJECT_NAMESPACE by default is set to "cp4waiops".     |
+|                                                          |
+|  If your install is in a namespace called "cp4waiops",   |
+|  then no change to this script is required.              | 
+|__________________________________________________________|
 
-NAMESPACE   NAME                 PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
-cp4waiops   aiops-installation   Running   Accepted   rook-cephfs    rook-cephfs              108m
+______________________________________________________________
+Installation instances:
 
-KIND                         NAMESPACE   NAME    STATUS
-IssueResolutionCore          cp4waiops   aiops   Ready
-AIOpsAnalyticsOrchestrator   cp4waiops   aiops   Ready
+NAMESPACE   NAME                  PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
+cp4waiops   ibm-cp-watson-aiops   Running   Accepted   rook-cephfs    rook-ceph-block          8d
+______________________________________________________________
+IRCore and AIOpsAnalyticsOrchestrator instances:
 
-KIND               NAMESPACE   NAME    STATUS
-LifecycleService   cp4waiops   aiops   LifecycleService ready
+KIND                         NAMESPACE   NAME    VERSION   STATUS
+IssueResolutionCore          cp4waiops   aiops   3.2.1     Ready
+AIOpsAnalyticsOrchestrator   cp4waiops   aiops   3.2.0     Ready
+______________________________________________________________
+LifecycleService instances:
 
-KIND     NAMESPACE   NAME              STATUS
-BaseUI   cp4waiops   baseui-instance   Ready
+KIND               NAMESPACE   NAME    VERSION   STATUS
+LifecycleService   cp4waiops   aiops   3.3.0     Ready
+______________________________________________________________
+BaseUI instances:
 
-KIND        NAMESPACE   NAME             STATUS
-AIManager   cp4waiops   aimanager        Completed
-AIOpsEdge   cp4waiops   aiopsedge        Configured
-ASM         cp4waiops   aiops-topology   OK
+KIND     NAMESPACE   NAME              VERSION   STATUS
+BaseUI   cp4waiops   baseui-instance   3.3.0     Ready
+______________________________________________________________
+AIManager, AIOpsEdge, and ASM instances:
 
-KIND                    NAMESPACE   NAME                    STATUS
-AutomationUIConfig      cp4waiops   iaf-system              True
-AutomationBase          cp4waiops   automationbase-sample   True
-Cartridge               cp4waiops   cp4waiops-cartridge     True
-CartridgeRequirements   cp4waiops   cp4waiops-cartridge     True
+KIND        NAMESPACE   NAME             VERSION   STATUS
+AIManager   cp4waiops   aimanager        2.4.0     Completed
+AIOpsEdge   cp4waiops   aiopsedge        <none>    Configured
+ASM         cp4waiops   aiops-topology   2.2.0     OK
+______________________________________________________________
+AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
 
-KIND         NAME                 NAMESPACE   STATUS      PROGRESS   MESSAGE
-ZenService   iaf-zen-cpdservice   cp4waiops   Completed   100%       The Current Operation Is Completed
+KIND                    NAMESPACE   NAME                    VERSION   STATUS
+AutomationUIConfig      cp4waiops   iaf-system              v1.3      True
+AutomationBase          cp4waiops   automationbase-sample   v2.0      True
+Cartridge               cp4waiops   cp4waiops-cartridge     v1.3      True
+CartridgeRequirements   cp4waiops   cp4waiops-cartridge     v1.3      True
+______________________________________________________________
+ZenService instances:
+
+KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
+ZenService   iaf-zen-cpdservice   cp4waiops   4.4.1     Completed   100%       The Current Operation Is Completed
+______________________________________________________________
+CSVs from cp4waiops namespace:
+
+NAME                                               DISPLAY                                            VERSION              REPLACES                                PHASE
+aimanager-operator.v3.3.0-202203130801             IBM Watson AIOps AI Manager                        3.3.0-202203130801   aimanager-operator.v3.2.1               Succeeded
+aiopsedge-operator.v3.3.0-202203130801             IBM Watson AIOps Edge                              3.3.0-202203130801   aiopsedge-operator.v3.2.1               Succeeded
+asm-operator.v3.3.0-202203130801                   IBM Netcool Agile Service Manager                  3.3.0-202203130801   asm-operator.v3.2.1                     Succeeded
+couchdb-operator.v2.2.1                            Operator for Apache CouchDB                        2.2.1                couchdb-operator.v2.2.0                 Succeeded
+ibm-aiops-ir-ai.v3.3.0-202203130801                IBM Watson AIOps Issue Resolution AI & Analytics   3.3.0-202203130801   ibm-aiops-ir-ai.v3.2.1                  Succeeded
+ibm-aiops-ir-core.v3.3.0-202203130801              IBM Watson AIOps Issue Resolution Core             3.3.0-202203130801   ibm-aiops-ir-core.v3.2.1                Succeeded
+ibm-aiops-ir-lifecycle.v3.3.0-202203130801         IBM Cloud Pak for Watson AIOps Lifecycle           3.3.0-202203130801   ibm-aiops-ir-lifecycle.v3.2.1           Succeeded
+ibm-aiops-orchestrator.v3.3.0-202203130801         IBM Cloud Pak for Watson AIOps AI Manager          3.3.0-202203130801   ibm-aiops-orchestrator.v3.2.1           Succeeded
+ibm-automation-core.v1.3.4                         IBM Automation Foundation Core                     1.3.4                ibm-automation-core.v1.3.3              Succeeded
+ibm-automation-elastic.v1.3.3                      IBM Elastic                                        1.3.3                ibm-automation-elastic.v1.3.2           Succeeded
+ibm-automation-eventprocessing.v1.3.4              IBM Automation Foundation Event Processing         1.3.4                ibm-automation-eventprocessing.v1.3.3   Succeeded
+ibm-automation-flink.v1.3.3                        IBM Automation Foundation Flink                    1.3.3                ibm-automation-flink.v1.3.2             Succeeded
+ibm-automation.v1.3.4                              IBM Automation Foundation                          1.3.4                ibm-automation.v1.3.3                   Succeeded
+ibm-cloud-databases-redis.v1.4.3                   IBM Operator for Redis                             1.4.3                ibm-cloud-databases-redis.v1.3.3        Succeeded
+ibm-common-service-operator.v3.16.1                IBM Cloud Pak foundational services                3.16.1               ibm-common-service-operator.v3.15.1     Succeeded
+ibm-management-kong.v3.3.0-202203130801            IBM Internal - IBM Watson AIOps Kong               3.3.0-202203130801   ibm-management-kong.v3.2.1              Succeeded
+ibm-postgreservice-operator.v3.3.0-202203130801    IBM Postgreservice                                 3.3.0-202203130801   ibm-postgreservice-operator.v3.2.1      Succeeded
+ibm-vault-operator.v3.3.0-202203130801             IBM Vault Operator                                 3.3.0-202203130801   ibm-vault-operator.v3.2.1               Succeeded
+ibm-watson-aiops-ui-operator.v3.3.0-202203130801   IBM Watson AIOps UI                                3.3.0-202203130801   ibm-watson-aiops-ui-operator.v3.2.1     Succeeded
+______________________________________________________________
+CSVs from ibm-common-services namespace:
+
+NAME                                                 DISPLAY                                VERSION   REPLACES                                       PHASE
+ibm-cert-manager-operator.v3.18.1                    IBM Cert Manager                       3.18.1    ibm-cert-manager-operator.v3.17.0              Succeeded
+ibm-common-service-operator.v3.16.1                  IBM Cloud Pak foundational services    3.16.1    ibm-common-service-operator.v3.15.1            Succeeded
+ibm-commonui-operator.v1.14.0                        Ibm Common UI                          1.14.0    ibm-commonui-operator.v1.13.0                  Succeeded
+ibm-crossplane-operator.v1.5.0                       IBM Crossplane                         1.5.0     ibm-crossplane-operator.v1.4.1                 Succeeded
+ibm-crossplane-provider-kubernetes-operator.v1.5.0   IBM Crossplane Provider Kubernetes     1.5.0                                                    Succeeded
+ibm-events-operator.v3.15.0                          IBM Events Operator                    3.15.0    ibm-events-operator.v3.14.2                    Succeeded
+ibm-iam-operator.v3.16.0                             IBM IAM Operator                       3.16.0    ibm-iam-operator.v3.13.0                       Succeeded
+ibm-ingress-nginx-operator.v1.13.0                   IBM Ingress Nginx Operator             1.13.0    ibm-ingress-nginx-operator.v1.12.0             Succeeded
+ibm-licensing-operator.v1.13.0                       IBM Licensing Operator                 1.13.0    ibm-licensing-operator.v1.12.0                 Succeeded
+ibm-management-ingress-operator.v1.13.0              Management Ingress Operator            1.13.0    ibm-management-ingress-operator.v1.12.0        Succeeded
+ibm-mongodb-operator.v1.11.0                         IBM MongoDB Operator                   1.11.0    ibm-mongodb-operator.v1.10.0                   Succeeded
+ibm-namespace-scope-operator.v1.10.0                 IBM NamespaceScope Operator            1.10.0    ibm-namespace-scope-operator.v1.9.0            Succeeded
+ibm-platform-api-operator.v3.18.0                    IBM Platform API                       3.18.0    ibm-platform-api-operator.v3.17.0              Succeeded
+ibm-zen-operator.v1.5.1                              IBM Zen Service                        1.5.1     ibm-zen-operator.v1.5.0                        Succeeded
+operand-deployment-lifecycle-manager.v1.14.0         Operand Deployment Lifecycle Manager   1.14.0    operand-deployment-lifecycle-manager.v1.13.0   Succeeded
+______________________________________________________________
+Subscriptions from cp4waiops namespace:
+
+NAME                                                                              PACKAGE                              SOURCE                  CHANNEL
+aimanager-operator                                                                aimanager-operator                   ibm-cp-waiops-catalog   3.3-dev
+aiopsedge-operator                                                                aiopsedge-operator                   ibm-cp-waiops-catalog   3.3-dev
+asm-operator                                                                      asm-operator                         ibm-cp-waiops-catalog   3.3-dev
+couchdb                                                                           couchdb-operator                     ibm-cp-waiops-catalog   v2.2
+ibm-aiops-orchestrator                                                            ibm-aiops-orchestrator               ibm-cp-waiops-catalog   3.3-dev
+ibm-automation-core-v1.3-ibm-cp-waiops-catalog-openshift-marketplace              ibm-automation-core                  ibm-cp-waiops-catalog   v1.3
+ibm-automation-elastic-v1.3-ibm-cp-waiops-catalog-openshift-marketplace           ibm-automation-elastic               ibm-cp-waiops-catalog   v1.3
+ibm-automation-eventprocessing-v1.3-ibm-cp-waiops-catalog-openshift-marketplace   ibm-automation-eventprocessing       ibm-cp-waiops-catalog   v1.3
+ibm-automation-flink-v1.3-ibm-cp-waiops-catalog-openshift-marketplace             ibm-automation-flink                 ibm-cp-waiops-catalog   v1.3
+ibm-automation-v1.3-ibm-cp-waiops-catalog-openshift-marketplace                   ibm-automation                       ibm-cp-waiops-catalog   v1.3
+ibm-common-service-operator-v3-ibm-cp-waiops-catalog-openshift-marketplace        ibm-common-service-operator          ibm-cp-waiops-catalog   v3
+ibm-management-kong                                                               ibm-management-kong                  ibm-cp-waiops-catalog   3.3-dev
+ibm-postgreservice-operator                                                       ibm-postgreservice-operator          ibm-cp-waiops-catalog   3.3-dev
+ibm-watson-aiops-ui-operator                                                      ibm-watson-aiops-ui-operator         ibm-cp-waiops-catalog   3.3-dev
+ir-ai-operator                                                                    ibm-aiops-ir-ai                      ibm-cp-waiops-catalog   3.3-dev
+ir-core-operator                                                                  ibm-aiops-ir-core                    ibm-cp-waiops-catalog   3.3-dev
+ir-lifecycle-operator                                                             ibm-aiops-ir-lifecycle               ibm-cp-waiops-catalog   3.3-dev
+redis                                                                             ibm-cloud-databases-redis-operator   ibm-cp-waiops-catalog   v1.4
+vault                                                                             ibm-vault-operator                   ibm-cp-waiops-catalog   3.3-dev
+______________________________________________________________
+Subscriptions from ibm-common-services namespace:
+
+NAME                                              PACKAGE                                           SOURCE                  CHANNEL
+ibm-cert-manager-operator                         ibm-cert-manager-operator                         ibm-cp-waiops-catalog   v3
+ibm-common-service-operator                       ibm-common-service-operator                       ibm-cp-waiops-catalog   v3
+ibm-commonui-operator                             ibm-commonui-operator-app                         ibm-cp-waiops-catalog   v3
+ibm-crossplane-operator-app                       ibm-crossplane-operator-app                       ibm-cp-waiops-catalog   v3
+ibm-crossplane-provider-kubernetes-operator-app   ibm-crossplane-provider-kubernetes-operator-app   ibm-cp-waiops-catalog   v3
+ibm-events-operator                               ibm-events-operator                               ibm-cp-waiops-catalog   v3
+ibm-iam-operator                                  ibm-iam-operator                                  ibm-cp-waiops-catalog   v3
+ibm-ingress-nginx-operator                        ibm-ingress-nginx-operator-app                    ibm-cp-waiops-catalog   v3
+ibm-licensing-operator                            ibm-licensing-operator-app                        ibm-cp-waiops-catalog   v3
+ibm-management-ingress-operator                   ibm-management-ingress-operator-app               ibm-cp-waiops-catalog   v3
+ibm-mongodb-operator                              ibm-mongodb-operator-app                          ibm-cp-waiops-catalog   v3
+ibm-namespace-scope-operator                      ibm-namespace-scope-operator                      ibm-cp-waiops-catalog   v3
+ibm-platform-api-operator                         ibm-platform-api-operator-app                     ibm-cp-waiops-catalog   v3
+ibm-zen-operator                                  ibm-zen-operator                                  ibm-cp-waiops-catalog   v3
+operand-deployment-lifecycle-manager-app          ibm-odlm                                          ibm-cp-waiops-catalog   v3
 ```
 
 ## How to use
@@ -54,6 +169,17 @@ Verify plugin:
 git clone https://github.com/IBM/cp4waiops-samples.git
 chmod +x cp4waiops-samples/kubectl-plugin/kubectl-waiops
 cp cp4waiops-samples/kubectl-plugin/kubectl-waiops /usr/local/bin/kubectl-waiops
+```
 
+Once you have done the above, make sure that your installation namespace is defined in the script.
+By default in the script, `PROJECT_NAMESPACE` is set to `cp4waiops`. If you have a different
+installation namespace name, please define the below variable with your namespace before proceeding:
+
+```
+export PROJECT_NAMESPACE="<your installation namespace>"
+```
+
+Once you have done the above, you can run the following command to use the status checker tool: 
+```
 oc waiops status
 ```

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -204,5 +204,4 @@ cp cp4waiops-samples/kubectl-plugin/kubectl-waiops /usr/local/bin/kubectl-waiops
 Once you have done the above, you can run the following commands to use the status checker tool: 
 ```
 oc waiops status 
-oc waiops upgrade-status
 ```

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -212,13 +212,10 @@ Meanwhile, the following component(s) have not upgraded yet:
 
 
 KIND               NAMESPACE   NAME    VERSION   STATUS
-LifecycleService   katamari    aiops   3.4.0     Ready
-
-KIND      NAMESPACE   NAME               VERSION
-AIOpsUI   katamari    aiopsui-instance   0.1.0
+LifecycleService   katamari    aiops   3.2.0     Ready
 
 KIND                  NAMESPACE   NAME    VERSION   STATUS
-IssueResolutionCore   katamari    aiops   3.4.0     Ready
+IssueResolutionCore   katamari    aiops   3.2.0     Ready
 
 If only a short time has passed since the upgrade was started, the components may
 need more time to complete upgrading. If you have waited a significant amount of time

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -151,6 +151,29 @@ ibm-platform-api-operator                         ibm-platform-api-operator-app 
 ibm-zen-operator                                  ibm-zen-operator                                  ibm-cp-waiops-catalog   v3
 operand-deployment-lifecycle-manager-app          ibm-odlm                                          ibm-cp-waiops-catalog   v3
 ______________________________________________________________
+OperandRequest instances:
+
+NAMESPACE             NAME                                  PHASE     CREATED AT
+cp4waiops             aiopsedge-base                        Running   2022-03-14T16:23:01Z
+cp4waiops             aiopsedge-cs                          Running   2022-03-14T16:23:01Z
+cp4waiops             iaf-core-operator                     Running   2022-03-14T15:58:24Z
+cp4waiops             iaf-eventprocessing-operator          Running   2022-03-14T15:58:24Z
+cp4waiops             iaf-operator                          Running   2022-03-14T15:58:25Z
+cp4waiops             iaf-system                            Running   2022-03-14T17:45:55Z
+cp4waiops             iaf-system-common-service             Running   2022-03-14T16:20:45Z
+cp4waiops             iaf-system-events                     Running   2022-03-14T16:20:45Z
+cp4waiops             ibm-aiops-ai-manager                  Running   2022-03-14T16:20:40Z
+cp4waiops             ibm-aiops-aiops-foundation            Running   2022-03-14T16:20:40Z
+cp4waiops             ibm-aiops-application-manager         Running   2022-03-14T16:20:40Z
+cp4waiops             ibm-elastic-operator                  Running   2022-03-14T15:58:24Z
+cp4waiops             ibm-iam-service                       Running   2022-03-14T16:42:40Z
+cp4waiops             operandrequest-kafkauser-iaf-system   Running   2022-03-14T17:45:48Z
+ibm-common-services   ibm-commonui-request                  Running   2022-03-14T16:21:14Z
+ibm-common-services   ibm-iam-request                       Running   2022-03-14T16:21:19Z
+ibm-common-services   ibm-mongodb-request                   Running   2022-03-14T16:22:30Z
+ibm-common-services   management-ingress                    Running   2022-03-14T16:22:30Z
+ibm-common-services   platform-api-request                  Running   2022-03-14T16:22:30Z
+______________________________________________________________
 ODLM pod current status:
 
 operand-deployment-lifecycle-manager-86599c9b7f-jx9h7            1/1     Running     0          7d7h

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -14,35 +14,35 @@ ______________________________________________________________
 Installation instances:
 
 NAMESPACE   NAME                 PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
-katamari    aiops-installation   Running   Accepted   rook-cephfs    rook-cephfs              4h54m
+katamari    aiops-installation   Running   Accepted   rook-cephfs    rook-cephfs              14h
 ______________________________________________________________
 IRCore and AIOpsAnalyticsOrchestrator instances:
 
 KIND                         NAMESPACE   NAME    VERSION   STATUS
-IssueResolutionCore          katamari    aiops   3.4.0     Ready
+IssueResolutionCore          katamari    aiops   3.3.0     Ready
 AIOpsAnalyticsOrchestrator   katamari    aiops   3.2.0     Ready
 ______________________________________________________________
 LifecycleService instances:
 
 KIND               NAMESPACE   NAME    VERSION   STATUS
-LifecycleService   katamari    aiops   3.4.0     Ready
+LifecycleService   katamari    aiops   3.3.0     Ready
 ______________________________________________________________
 BaseUI instances:
 
 KIND     NAMESPACE   NAME              VERSION   STATUS
-BaseUI   katamari    baseui-instance   0.1.0     Ready
+BaseUI   katamari    baseui-instance   3.3.1     Ready
 ______________________________________________________________
 AIManager, ASM, AIOpsEdge, and AIOpsUI instances:
 
 KIND        NAMESPACE   NAME             VERSION   STATUS
 AIManager   katamari    aimanager        2.4.0     Completed
-ASM         katamari    aiops-topology   2.2.0     OK
+ASM         katamari    aiops-topology   2.5.0     OK
 
 KIND        NAMESPACE   NAME        STATUS
 AIOpsEdge   katamari    aiopsedge   Configured
 
 KIND      NAMESPACE   NAME               VERSION
-AIOpsUI   katamari    aiopsui-instance   0.1.0
+AIOpsUI   katamari    aiopsui-instance   3.3.1
 ______________________________________________________________
 AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
 
@@ -59,33 +59,33 @@ Kong   katamari    gateway
 ______________________________________________________________
 ZenService instances:
 
-KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
-ZenService   iaf-zen-cpdservice   katamari    4.4.3     Completed   100%       The Current Operation Is Completed
+KIND         NAME                 NAMESPACE   VERSION   STATUS
+ZenService   iaf-zen-cpdservice   katamari    4.4.3     Completed
 ______________________________________________________________
 CSVs from katamari namespace:
 
 NAME                                               DISPLAY                                            VERSION              REPLACES                                PHASE
-aimanager-operator.v0.1.0-202203281601             IBM Watson AIOps AI Manager                        0.1.0-202203281601                                           Succeeded
-aiopsedge-operator.v0.1.0-202203281601             IBM Watson AIOps Edge                              0.1.0-202203281601                                           Succeeded
-asm-operator.v0.1.0-202203281601                   IBM Netcool Agile Service Manager                  0.1.0-202203281601                                           Succeeded
+aimanager-operator.v3.3.1-202203282001             IBM Watson AIOps AI Manager                        3.3.1-202203282001                                           Succeeded
+aiopsedge-operator.v3.3.1-202203282001             IBM Watson AIOps Edge                              3.3.1-202203282001                                           Succeeded
+asm-operator.v3.3.1-202203282001                   IBM Netcool Agile Service Manager                  3.3.1-202203282001                                           Succeeded
 couchdb-operator.v2.2.1                            Operator for Apache CouchDB                        2.2.1                couchdb-operator.v2.2.0                 Succeeded
 elasticsearch-operator.5.3.5-20                    OpenShift Elasticsearch Operator                   5.3.5-20                                                     Succeeded
-ibm-aiops-ir-ai.v0.1.0-202203281601                IBM Watson AIOps Issue Resolution AI & Analytics   0.1.0-202203281601                                           Succeeded
-ibm-aiops-ir-core.v0.1.0-202203281601              IBM Watson AIOps Issue Resolution Core             0.1.0-202203281601                                           Succeeded
-ibm-aiops-ir-lifecycle.v0.1.0-202203281601         IBM Cloud Pak for Watson AIOps Lifecycle           0.1.0-202203281601                                           Succeeded
-ibm-aiops-orchestrator.v0.1.0-202203281601         IBM Cloud Pak for Watson AIOps AI Manager          0.1.0-202203281601                                           Succeeded
+ibm-aiops-ir-ai.v3.3.1-202203282001                IBM Watson AIOps Issue Resolution AI & Analytics   3.3.1-202203282001                                           Succeeded
+ibm-aiops-ir-core.v3.3.1-202203282001              IBM Watson AIOps Issue Resolution Core             3.3.1-202203282001                                           Succeeded
+ibm-aiops-ir-lifecycle.v3.3.1-202203282001         IBM Cloud Pak for Watson AIOps Lifecycle           3.3.1-202203282001                                           Succeeded
+ibm-aiops-orchestrator.v3.3.1-202203282001         IBM Cloud Pak for Watson AIOps AI Manager          3.3.1-202203282001                                           Succeeded
 ibm-automation-core.v1.3.5                         IBM Automation Foundation Core                     1.3.5                ibm-automation-core.v1.3.4              Succeeded
 ibm-automation-elastic.v1.3.4                      IBM Elastic                                        1.3.4                ibm-automation-elastic.v1.3.3           Succeeded
 ibm-automation-eventprocessing.v1.3.5              IBM Automation Foundation Event Processing         1.3.5                ibm-automation-eventprocessing.v1.3.4   Succeeded
 ibm-automation-flink.v1.3.4                        IBM Automation Foundation Flink                    1.3.4                ibm-automation-flink.v1.3.3             Succeeded
 ibm-automation.v1.3.5                              IBM Automation Foundation                          1.3.5                ibm-automation.v1.3.4                   Succeeded
 ibm-cloud-databases-redis.v1.4.3                   IBM Operator for Redis                             1.4.3                ibm-cloud-databases-redis.v1.4.2        Succeeded
-ibm-common-service-operator.v3.17.0                IBM Cloud Pak foundational services                3.17.0               ibm-common-service-operator.v3.16.1     Succeeded
-ibm-management-kong.v0.1.0-202203281601            IBM Internal - IBM Watson AIOps Kong               0.1.0-202203281601                                           Succeeded
-ibm-postgreservice-operator.v0.1.0-202203281601    IBM Postgreservice                                 0.1.0-202203281601                                           Succeeded
-ibm-secure-tunnel-operator.v0.1.0-202203281601     IBM Secure Tunnel                                  0.1.0-202203281601                                           Succeeded
-ibm-vault-operator.v0.1.0-202203281601             IBM Vault Operator                                 0.1.0-202203281601                                           Succeeded
-ibm-watson-aiops-ui-operator.v0.1.0-202203281601   IBM Watson AIOps UI                                0.1.0-202203281601                                           Succeeded
+ibm-common-service-operator.v3.17.0                IBM Cloud Pak foundational services                3.17.0               ibm-common-service-operator.v3.16.3     Succeeded
+ibm-management-kong.v3.3.1-202203282001            IBM Internal - IBM Watson AIOps Kong               3.3.1-202203282001                                           Succeeded
+ibm-postgreservice-operator.v3.3.1-202203282001    IBM Postgreservice                                 3.3.1-202203282001                                           Succeeded
+ibm-secure-tunnel-operator.v3.3.1-202203282001     IBM Secure Tunnel                                  3.3.1-202203282001                                           Succeeded
+ibm-vault-operator.v3.3.1-202203282001             IBM Vault Operator                                 3.3.1-202203282001                                           Succeeded
+ibm-watson-aiops-ui-operator.v3.3.1-202203282001   IBM Watson AIOps UI                                3.3.1-202203282001                                           Succeeded
 ______________________________________________________________
 CSVs from ibm-common-services namespace:
 
@@ -109,27 +109,27 @@ operand-deployment-lifecycle-manager.v1.15.0         Operand Deployment Lifecycl
 ______________________________________________________________
 Subscriptions from katamari namespace:
 
-NAME                                                                       PACKAGE                              SOURCE                  CHANNEL
-aimanager-operator                                                         aimanager-operator                   ibm-cp-waiops-catalog   0.1-dev
-aiopsedge-operator                                                         aiopsedge-operator                   ibm-cp-waiops-catalog   0.1-dev
-asm-operator                                                               asm-operator                         ibm-cp-waiops-catalog   0.1-dev
-couchdb                                                                    couchdb-operator                     ibm-cp-waiops-catalog   v2.2
-ibm-aiops-orchestrator                                                     ibm-aiops-orchestrator               ibm-cp-waiops-catalog   0.1-dev
-ibm-automation                                                             ibm-automation                       iaf-operators           v1.3
-ibm-automation-core-v1.3-iaf-core-operators-openshift-marketplace          ibm-automation-core                  iaf-core-operators      v1.3
-ibm-automation-elastic-v1.3-iaf-operators-openshift-marketplace            ibm-automation-elastic               iaf-operators           v1.3
-ibm-automation-eventprocessing-v1.3-iaf-operators-openshift-marketplace    ibm-automation-eventprocessing       iaf-operators           v1.3
-ibm-automation-flink-v1.3-iaf-operators-openshift-marketplace              ibm-automation-flink                 iaf-operators           v1.3
-ibm-common-service-operator-v3-opencloud-operators-openshift-marketplace   ibm-common-service-operator          opencloud-operators     v3
-ibm-management-kong                                                        ibm-management-kong                  ibm-cp-waiops-catalog   0.1-dev
-ibm-postgreservice-operator                                                ibm-postgreservice-operator          ibm-cp-waiops-catalog   0.1-dev
-ibm-secure-tunnel-operator                                                 ibm-secure-tunnel-operator           ibm-cp-waiops-catalog   0.1-dev
-ibm-watson-aiops-ui-operator                                               ibm-watson-aiops-ui-operator         ibm-cp-waiops-catalog   0.1-dev
-ir-ai-operator                                                             ibm-aiops-ir-ai                      ibm-cp-waiops-catalog   0.1-dev
-ir-core-operator                                                           ibm-aiops-ir-core                    ibm-cp-waiops-catalog   0.1-dev
-ir-lifecycle-operator                                                      ibm-aiops-ir-lifecycle               ibm-cp-waiops-catalog   0.1-dev
-redis                                                                      ibm-cloud-databases-redis-operator   ibm-cp-waiops-catalog   v1.4
-vault                                                                      ibm-vault-operator                   ibm-cp-waiops-catalog   0.1-dev
+NAME                                                                         PACKAGE                              SOURCE                  CHANNEL
+aimanager-operator                                                           aimanager-operator                   ibm-cp-waiops-catalog   3.3-dev
+aiopsedge-operator                                                           aiopsedge-operator                   ibm-cp-waiops-catalog   3.3-dev
+asm-operator                                                                 asm-operator                         ibm-cp-waiops-catalog   3.3-dev
+couchdb                                                                      couchdb-operator                     ibm-cp-waiops-catalog   v2.2
+ibm-aiops-orchestrator                                                       ibm-aiops-orchestrator               ibm-cp-waiops-catalog   3.3-dev
+ibm-automation                                                               ibm-automation                       iaf-operators           v1.3
+ibm-automation-core-v1.3-iaf-core-operators-openshift-marketplace            ibm-automation-core                  iaf-core-operators      v1.3
+ibm-automation-elastic-v1.3-iaf-operators-openshift-marketplace              ibm-automation-elastic               iaf-operators           v1.3
+ibm-automation-eventprocessing-v1.3-iaf-operators-openshift-marketplace      ibm-automation-eventprocessing       iaf-operators           v1.3
+ibm-automation-flink-v1.3-iaf-operators-openshift-marketplace                ibm-automation-flink                 iaf-operators           v1.3
+ibm-common-service-operator-v3-ibm-cp-waiops-catalog-openshift-marketplace   ibm-common-service-operator          opencloud-operators     v3
+ibm-management-kong                                                          ibm-management-kong                  ibm-cp-waiops-catalog   3.3-dev
+ibm-postgreservice-operator                                                  ibm-postgreservice-operator          ibm-cp-waiops-catalog   3.3-dev
+ibm-secure-tunnel-operator                                                   ibm-secure-tunnel-operator           ibm-cp-waiops-catalog   3.3-dev
+ibm-watson-aiops-ui-operator                                                 ibm-watson-aiops-ui-operator         ibm-cp-waiops-catalog   3.3-dev
+ir-ai-operator                                                               ibm-aiops-ir-ai                      ibm-cp-waiops-catalog   3.3-dev
+ir-core-operator                                                             ibm-aiops-ir-core                    ibm-cp-waiops-catalog   3.3-dev
+ir-lifecycle-operator                                                        ibm-aiops-ir-lifecycle               ibm-cp-waiops-catalog   3.3-dev
+redis                                                                        ibm-cloud-databases-redis-operator   ibm-cp-waiops-catalog   v1.4
+vault                                                                        ibm-vault-operator                   ibm-cp-waiops-catalog   3.3-dev
 ______________________________________________________________
 Subscriptions from ibm-common-services namespace:
 
@@ -153,79 +153,33 @@ ______________________________________________________________
 OperandRequest instances:
 
 NAMESPACE             NAME                                  PHASE     CREATED AT
-ibm-common-services   ibm-commonui-request                  Running   2022-03-28T21:24:19Z
-ibm-common-services   ibm-iam-request                       Running   2022-03-28T21:24:20Z
-ibm-common-services   ibm-mongodb-request                   Running   2022-03-28T21:25:29Z
-ibm-common-services   management-ingress                    Running   2022-03-28T21:25:29Z
-ibm-common-services   platform-api-request                  Running   2022-03-28T21:25:29Z
-katamari              aiopsedge-base                        Running   2022-03-28T21:25:53Z
-katamari              aiopsedge-cs                          Running   2022-03-28T21:25:53Z
-katamari              iaf-core-operator                     Running   2022-03-28T21:21:30Z
-katamari              iaf-eventprocessing-operator          Running   2022-03-28T21:21:23Z
-katamari              iaf-operator                          Running   2022-03-28T21:21:22Z
-katamari              iaf-system                            Running   2022-03-28T21:29:49Z
-katamari              iaf-system-common-service             Running   2022-03-28T21:24:16Z
-katamari              ibm-aiops-ai-manager                  Running   2022-03-28T21:23:42Z
-katamari              ibm-aiops-aiops-foundation            Running   2022-03-28T21:23:42Z
-katamari              ibm-aiops-application-manager         Running   2022-03-28T21:23:42Z
-katamari              ibm-aiops-connection                  Running   2022-03-28T21:23:42Z
-katamari              ibm-elastic-operator                  Running   2022-03-28T21:21:33Z
-katamari              ibm-iam-service                       Running   2022-03-28T21:39:37Z
-katamari              operandrequest-kafkauser-iaf-system   Running   2022-03-28T21:46:59Z
+ibm-common-services   ibm-commonui-request                  Running   2022-03-29T05:19:25Z
+ibm-common-services   ibm-iam-request                       Running   2022-03-29T05:19:25Z
+ibm-common-services   ibm-mongodb-request                   Running   2022-03-29T05:20:14Z
+ibm-common-services   management-ingress                    Running   2022-03-29T05:20:14Z
+ibm-common-services   platform-api-request                  Running   2022-03-29T05:20:14Z
+katamari              aiopsedge-base                        Running   2022-03-29T05:25:27Z
+katamari              aiopsedge-cs                          Running   2022-03-29T05:25:27Z
+katamari              iaf-core-operator                     Running   2022-03-29T05:16:19Z
+katamari              iaf-eventprocessing-operator          Running   2022-03-29T05:16:14Z
+katamari              iaf-operator                          Running   2022-03-29T05:16:10Z
+katamari              iaf-system                            Running   2022-03-29T05:29:15Z
+katamari              iaf-system-common-service             Running   2022-03-29T05:19:20Z
+katamari              ibm-aiops-ai-manager                  Running   2022-03-29T05:18:50Z
+katamari              ibm-aiops-aiops-foundation            Running   2022-03-29T05:18:50Z
+katamari              ibm-aiops-application-manager         Running   2022-03-29T05:18:50Z
+katamari              ibm-aiops-connection                  Running   2022-03-29T05:18:50Z
+katamari              ibm-elastic-operator                  Running   2022-03-29T05:16:21Z
+katamari              ibm-iam-service                       Running   2022-03-29T05:43:37Z
+katamari              operandrequest-kafkauser-iaf-system   Running   2022-03-29T05:52:39Z
 ______________________________________________________________
 ODLM pod current status:
 
-operand-deployment-lifecycle-manager-79b789fd56-gkdd4           1/1     Running     0               4h55m
+ibm-common-services                                operand-deployment-lifecycle-manager-687db67764-zb86w               1/1     Running     0          14h
 ______________________________________________________________
 Orchestrator pod current status:
 
-ibm-aiops-orchestrator-controller-manager-5787df5997-sz87g        1/1     Running            0                4h55m
-```
-
-### Status checker for upgrade scenario:
-```
-$ oc waiops upgrade-status
-
-Enter your Cloud Pak for Watson AIOps installation namespace: katamari
-
-______________________________________________________________
-
-The following component(s) have finished upgrading:
-
-
-KIND        NAMESPACE   NAME        STATUS
-AIOpsEdge   katamari    aiopsedge   Configured
-
-KIND   NAMESPACE   NAME
-Kong   katamari    gateway
-
-KIND        NAMESPACE   NAME        VERSION   STATUS
-AIManager   katamari    aimanager   2.4.0     Completed
-
-KIND                         NAMESPACE   NAME    VERSION   STATUS
-AIOpsAnalyticsOrchestrator   katamari    aiops   3.2.0     Ready
-
-______________________________________________________________
-
-______________________________________________________________
-
-Meanwhile, the following component(s) have not upgraded yet:
-
-
-KIND               NAMESPACE   NAME    VERSION   STATUS
-LifecycleService   katamari    aiops   3.2.0     Ready
-
-KIND                  NAMESPACE   NAME    VERSION   STATUS
-IssueResolutionCore   katamari    aiops   3.2.0     Ready
-
-If only a short time has passed since the upgrade was started, the components may
-need more time to complete upgrading. If you have waited a significant amount of time
-and the statuses of the components listed below are not changing, please refer to
-the troubleshooting docs or open a support case.
-
-______________________________________________________________
-
-Hint: for a more detailed printout of each operator's components' statuses, run `oc waiops status`.
+katamari                                           ibm-aiops-orchestrator-controller-manager-797979ccf8-9nzzs          1/1     Running     0          14h
 ```
 
 ## How to use


### PR DESCRIPTION
Added several updates to the status checker tool, including:
1. version numbers for all components
2. subscription details for all subs in the `ibm-common-services` and project namespaces
3. ODLM/orchestrator pod names and current statuses at script runtime
4. Upgrade details for the `ibm-common-services` and project namespace CSVs to show what each CSV updated from, etc.
5. newer format to separate all the outputted information to make it clearer
7. doc updates to include new steps and new example output

This is outputted with `oc waiops status` (i.e. no new oc commands with these updates above). The proposed doc changes in `waiops-status.md` show an example output of the script.

The new command `oc waiops upgrade-status` (for checking component upgrading) is in a separate PR here: https://github.com/IBM/cp4waiops-samples/pull/52