### PR TITLE
affinity check added

### DIFF
--- a/prereq-checker/3.3/prereq.sh
+++ b/prereq-checker/3.3/prereq.sh
@@ -250,6 +250,15 @@ createTestJob () {
         metadata:
           name: pi
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
           imagePullSecrets:
           - name: ibm-entitlement-key
           containers:
@@ -273,6 +282,15 @@ EOF
         metadata:
           name: pi
         spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
           containers:
           - name: testimage
             image: cp.icr.io/cp/cp4waiops/ai-platform-api-server@sha256:3c08f68c1ce898728b86ce9e570b08018fa8cf27a08df8603a2cd301cfae735a


### PR DESCRIPTION
Cause : The prereq checker tool was failing for the entitlement-key secret check, and the issue was the job pod for entilement key secret is not designed for the multi architecture image check.

```
[Taylor George]

I think our orchestrator was multi arch in previous releases but just noticed now that we may no longer build power but have it included in affinity.  IA supports ppc64le architechture, AI manager does not 

So this is not a valid use case for AI manager pre-req script...if this is for IA this is new use CASE but would also change how we need to run the other checks like resource requirements, etc if this script needs to be dual purpose. We also don't cover Event Manager considerations

So for AI Manager job in pre-req checker we should add the affinity rule (link above) for just amd64

```


Additional check on prereq checker tool : 

We added the affinity check for the job pod, now  if the tool is run against the environment other than `amd64`(Cloud pak for watson aiops aimanager supported) which is `ppc64le`(Cloud pak for Infrastructure automation supported) architecture it will not allow the job pod container to be scheduled with proper error as shown below :  

<img width="1363" alt="Screen Shot 2022-04-04 at 10 54 09 AM" src="https://user-images.githubusercontent.com/53223993/161583649-d55f9bc5-e0cc-4c5c-83d2-124c2b1e23ef.png">

