### PR TITLE
[uninstall v0.4] Removed duplicated kafka crd deletion from resource groups file so th…

### DIFF
--- a/uninstall/3.3/uninstall-cp4waiops-helper.sh
+++ b/uninstall/3.3/uninstall-cp4waiops-helper.sh
@@ -447,6 +447,7 @@ delete_iaf_bedrock () {
         oc delete deployment ibm-common-service-webhook -n ibm-common-services --ignore-not-found
         oc delete deployment meta-api-deploy -n ibm-common-services --ignore-not-found
         oc delete deployment secretshare -n ibm-common-services --ignore-not-found
+        oc get role.rbac.authorization.k8s.io --no-headers -o name | grep nss-runtime-managed-role-from-ibm-common-services | while read a b; do oc delete "$a"; done
 
         oc delete service cert-manager-webhook -n ibm-common-services --ignore-not-found
         oc delete service ibm-common-service-webhook -n ibm-common-services --ignore-not-found

--- a/uninstall/3.3/uninstall-cp4waiops-resource-groups.props
+++ b/uninstall/3.3/uninstall-cp4waiops-resource-groups.props
@@ -42,17 +42,6 @@ CP4WAIOPS_DEPENDENT_CRDS=(#elasticsearch
                           "formations.couchdb.databases.cloud.ibm.com"
                           "recipes.couchdb.databases.cloud.ibm.com"
                           "recipetemplates.couchdb.databases.cloud.ibm.com"
-                          #EventsOperator
-                          "kafkabridges.ibmevents.ibm.com"
-                          "kafkaconnectors.ibmevents.ibm.com"
-                          "kafkaconnects.ibmevents.ibm.com"
-                          "kafkaconnects2is.ibmevents.ibm.com"
-                          "kafkamirrormaker2s.ibmevents.ibm.com"
-                          "kafkamirrormakers.ibmevents.ibm.com"
-                          "kafkarebalances.ibmevents.ibm.com"
-                          "kafkas.ibmevents.ibm.com"
-                          "kafkatopics.ibmevents.ibm.com"
-                          "kafkausers.ibmevents.ibm.com"
                           #PostgresOperator
                           "postgreservices.postgres.aiops.ibm.com"
                           "postgresdbs.postgres.aiops.ibm.com"

--- a/uninstall/3.3/uninstall-cp4waiops.sh
+++ b/uninstall/3.3/uninstall-cp4waiops.sh
@@ -36,7 +36,7 @@ analyze_script_properties
 
 # Confirm we really want to uninstall 
 if [[ $SKIP_CONFIRM != "true" ]]; then
-  log $INFO "\033[0;33mUninstall v0.3 for AIOPs v3.3\033[0m"
+  log $INFO "\033[0;33mUninstall v0.4 for AIOPs v3.3\033[0m"
   log $INFO
   log $INFO "This script will uninstall IBM Cloud Pak for AIOps version 3.3. Please ensure you have deleted any CRs you created before running this script."
   log $INFO ""
@@ -55,6 +55,7 @@ if [[ $SKIP_CONFIRM != "true" ]]; then
     exit 0
   fi
 else
+  log $INFO "\033[0;33mUninstall v0.4 for AIOPs v3.3\033[0m"
   log $INFO
   log $INFO "This script will uninstall IBM Cloud Pak for AIOps."
   display_script_properties


### PR DESCRIPTION
…at they are only deleted when ONLY_CLOUDPAK=true
Added line to remove nss-runtime-managed-role-from-ibm-common-services (all instances) when deleting CPP
Updated uninstall minor version