### PR TITLE
Next set of status checker tool updates

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -45,8 +45,8 @@ then
     oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
 
     echo "______________________________________________________________"
-    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
-    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
+    echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""
+    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
     
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
@@ -86,8 +86,8 @@ then
     oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
 
     echo "______________________________________________________________"
-    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
-    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
+    echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""
+    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
     
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
@@ -335,6 +335,20 @@ then
         fi
     }
 
+    FlinkEventProcessorUpgradeStatus() {
+        FLINK_EP_COMPLETED=$(oc get EventProcessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+        CURRENT_MAJOR_VERSION=$(oc get EventProcessor cp4waiops-eventprocessor -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
+        DETAILS=$(oc get EventProcessor cp4waiops-eventprocessor -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+        if [ "${FLINK_EP_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "4.0" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
     # Run component status checks
     aiopsEdgeBaseUpgradeStatus
     lifecycleUpgradeStatus
@@ -347,6 +361,7 @@ then
     vaultAccessUpgradeStatus
     postgresUpgradeStatus
     asmUpgradeStatus
+    FlinkEventProcessorUpgradeStatus
 
     # Print out results of status checks
     printf "

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -22,7 +22,7 @@ INSTALLATION_NAMESPACE=$(oc get installations.orchestrator.aiops.ibm.com -A --no
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.5"
+    echo "0.0.6"
     exit 0
 fi
 
@@ -39,6 +39,14 @@ then
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
     oc get installations.orchestrator.aiops.ibm.com -A 
+    
+    echo "______________________________________________________________"
+    echo "ZenService instances:" && echo ""
+    oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+
+    echo "______________________________________________________________"
+    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
+    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
     
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
@@ -59,18 +67,51 @@ then
     oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
     oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
 
+    printf "
+${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status-all\`.
+${normal}
+"
+    exit 0
+fi
+
+# optional argument handling
+if [[ "$1" == "status-all" ]]
+then
     echo "______________________________________________________________"
-    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
-    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
-    
-    echo "______________________________________________________________"
-    echo "Kong instances:" && echo ""
-    oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:.status.conditions[?(@.type==\"Deployed\")].status,MESSAGE:status.conditions[?(@.type==\"Deployed\")].reason"         
+    echo "Installation instances:" && echo ""
+    oc get installations.orchestrator.aiops.ibm.com -A 
     
     echo "______________________________________________________________"
     echo "ZenService instances:" && echo ""
     oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
 
+    echo "______________________________________________________________"
+    echo "AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:" && echo ""
+    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
+    
+    echo "______________________________________________________________"
+    echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
+    oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message"
+    
+    echo "______________________________________________________________"
+    echo "LifecycleService instances:" && echo ""
+    oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message"
+    
+    echo "______________________________________________________________"
+    echo "BaseUI instances:" && echo ""
+    oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
+    oc get AIManager -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
+    oc get asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
+    oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
+    oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
+    
+    echo "______________________________________________________________"
+    echo "Kong instances:" && echo ""
+    oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:.status.conditions[?(@.type==\"Deployed\")].status,MESSAGE:status.conditions[?(@.type==\"Deployed\")].reason"         
+    
     echo "______________________________________________________________"
     echo "Vault (VaultDeploy and VaultAccess) instances:" && echo ""
     oc get vaultdeploy,vaultaccess -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message"
@@ -106,12 +147,13 @@ then
     echo "______________________________________________________________"
     echo "Orchestrator pod current status:" && echo ""
     oc get pod -A | grep ibm-aiops-orchestrator-controller-manager    
+    
     echo ""
     exit 0
 fi
 
 # optional argument handling
-if [[ "$1" == "upgrade-status" ]]
+if [[ "$1" == "status-upgrade" ]]
 then
     # Script to check upgrade status of CP4WAIOps install for v3.3
     # This script checks to see if your Cloud Pak for Watson AIOps
@@ -333,7 +375,7 @@ ${bold}${red}______________________________________________________________
     fi
 
     printf "
-${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status\`.
+${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status\` or \`oc waiops status-all\`.
 ${normal}
 "
     exit 0

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -5,7 +5,7 @@ A kubectl plugin for CP4WAIOps
 https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
 
 ## Highlights
-Run `oc waiops status` to print out the status of some of your instance's main components. You can also run `oc waiops status-all` for a more detailed printout with more components.
+Run `oc waiops status` to print the statuses of some of your instance's main components. If you see components with issues (or are generally facing issues on your cluster), run `oc waiops status-all` for a more detailed printout with more components.
 
 If you are upgrading your instance to the latest version, run `oc waiops status-upgrade`, which returns a list of components that have (and have not) completed upgrading. 
 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -297,7 +297,7 @@ ASM    cp4waiops   aiops-topology   2.5.0     OK
 
 ______________________________________________________________
 
-Hint: for a more detailed printout of each operator's components' statuses, run `oc waiops status`.
+Hint: for a more detailed printout of each operator's components' statuses, run `oc waiops status` or `oc waiops status-all`.
 ```
 
 ## How to use

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -28,11 +28,13 @@ ZenService   iaf-zen-cpdservice   cp4waiops   4.4.2     Completed   100%       T
 ______________________________________________________________
 AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
 
-KIND                    NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
-AutomationUIConfig      cp4waiops   iaf-system              1.3.3     True     AutomationUIConfig successfully registered
-AutomationBase          cp4waiops   automationbase-sample   2.0.3     True     AutomationBase instance successfully created
-Cartridge               cp4waiops   cp4waiops-cartridge     1.3.3     True     Cartridge successfully registered
-CartridgeRequirements   cp4waiops   cp4waiops-cartridge     1.3.3     True     CartridgeRequirements successfully registered
+KIND                    NAMESPACE   NAME                       VERSION   STATUS   MESSAGE
+AutomationUIConfig      cp4waiops   iaf-system                 1.3.3     True     AutomationUIConfig successfully registered
+AutomationBase          cp4waiops   automationbase-sample      2.0.3     True     AutomationBase instance successfully created
+Cartridge               cp4waiops   cp4waiops-cartridge        1.3.3     True     Cartridge successfully registered
+CartridgeRequirements   cp4waiops   cp4waiops-cartridge        1.3.3     True     CartridgeRequirements successfully registered
+EventProcessor          cp4waiops   aiops-ir-lifecycle         3.0.0     True     Event Processor is ready
+EventProcessor          cp4waiops   cp4waiops-eventprocessor   4.0.5     True     Event Processor is ready
 ______________________________________________________________
 IRCore and AIOpsAnalyticsOrchestrator instances:
 
@@ -84,11 +86,13 @@ ZenService   iaf-zen-cpdservice   cp4waiops   4.4.2     Completed   100%       T
 ______________________________________________________________
 AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
 
-KIND                    NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
-AutomationUIConfig      cp4waiops   iaf-system              1.3.3     True     AutomationUIConfig successfully registered
-AutomationBase          cp4waiops   automationbase-sample   2.0.3     True     AutomationBase instance successfully created
-Cartridge               cp4waiops   cp4waiops-cartridge     1.3.3     True     Cartridge successfully registered
-CartridgeRequirements   cp4waiops   cp4waiops-cartridge     1.3.3     True     CartridgeRequirements successfully registered
+KIND                    NAMESPACE   NAME                       VERSION   STATUS   MESSAGE
+AutomationUIConfig      cp4waiops   iaf-system                 1.3.3     True     AutomationUIConfig successfully registered
+AutomationBase          cp4waiops   automationbase-sample      2.0.3     True     AutomationBase instance successfully created
+Cartridge               cp4waiops   cp4waiops-cartridge        1.3.3     True     Cartridge successfully registered
+CartridgeRequirements   cp4waiops   cp4waiops-cartridge        1.3.3     True     CartridgeRequirements successfully registered
+EventProcessor          cp4waiops   aiops-ir-lifecycle         3.0.0     True     Event Processor is ready
+EventProcessor          cp4waiops   cp4waiops-eventprocessor   4.0.5     True     Event Processor is ready
 ______________________________________________________________
 IRCore and AIOpsAnalyticsOrchestrator instances:
 
@@ -294,6 +298,9 @@ PostgresDB       cp4waiops   cp4waiops-postgresdb   1.0.0     True     Success t
 
 KIND   NAMESPACE   NAME             VERSION   STATUS
 ASM    cp4waiops   aiops-topology   2.5.0     OK
+
+KIND             NAMESPACE   NAME                       VERSION   STATUS   MESSAGE
+EventProcessor   cp4waiops   cp4waiops-eventprocessor   4.0.5     True     Event Processor is ready
 
 ______________________________________________________________
 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -69,7 +69,7 @@ Hint: for a more detailed printout of each operator's components' statuses, run 
 
 ### Detailed installation status checker output (`oc waiops status-all`)
 ```
-$ oc waiops status
+$ oc waiops status-all
 
 ______________________________________________________________
 Installation instances:
@@ -254,7 +254,7 @@ cp4waiops                                          ibm-aiops-orchestrator-contro
 
 ### Upgrade status checker (`oc waiops status-upgrade`):
 ```
-$ oc waiops upgrade-status
+$ oc waiops status-upgrade
 
 ______________________________________________________________
 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -5,9 +5,13 @@ A kubectl plugin for CP4WAIOps
 https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
 
 ## Highlights
+Run `oc waiops status` to print out the status of some of your instance's main components. You can also run `oc waiops status-all` for a more detailed printout with more components.
 
+If you are upgrading your instance to the latest version, run `oc waiops status-upgrade`, which returns a list of components that have (and have not) completed upgrading. 
 
-### Installation status checker
+Below are example outputs of these commands.
+
+### Installation status checker output (`oc waiops status`)
 ```
 $ oc waiops status
 
@@ -16,6 +20,75 @@ Installation instances:
 
 NAMESPACE   NAME                  PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
 cp4waiops   ibm-cp-watson-aiops   Running   Accepted   rook-cephfs    rook-ceph-block          63m
+______________________________________________________________
+ZenService instances:
+
+KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
+ZenService   iaf-zen-cpdservice   cp4waiops   4.4.2     Completed   100%       The Current Operation Is Completed
+______________________________________________________________
+AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
+
+KIND                    NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
+AutomationUIConfig      cp4waiops   iaf-system              1.3.3     True     AutomationUIConfig successfully registered
+AutomationBase          cp4waiops   automationbase-sample   2.0.3     True     AutomationBase instance successfully created
+Cartridge               cp4waiops   cp4waiops-cartridge     1.3.3     True     Cartridge successfully registered
+CartridgeRequirements   cp4waiops   cp4waiops-cartridge     1.3.3     True     CartridgeRequirements successfully registered
+______________________________________________________________
+IRCore and AIOpsAnalyticsOrchestrator instances:
+
+KIND                         NAMESPACE   NAME    VERSION   STATUS   MESSAGE
+IssueResolutionCore          cp4waiops   aiops   3.3.0     Ready    All Services Ready
+AIOpsAnalyticsOrchestrator   cp4waiops   aiops   3.2.0     Ready    All Services Ready
+______________________________________________________________
+LifecycleService instances:
+
+KIND               NAMESPACE   NAME    VERSION   STATUS   MESSAGE
+LifecycleService   cp4waiops   aiops   3.3.0     Ready    All Services Ready
+______________________________________________________________
+BaseUI instances:
+
+KIND     NAMESPACE   NAME              VERSION   STATUS   MESSAGE
+BaseUI   cp4waiops   baseui-instance   3.3.0     True     Ready
+______________________________________________________________
+AIManager, ASM, AIOpsEdge, and AIOpsUI instances:
+
+KIND        NAMESPACE   NAME        VERSION   STATUS      MESSAGE
+AIManager   cp4waiops   aimanager   2.4.0     Completed   AI Manager is ready
+
+KIND   NAMESPACE   NAME             VERSION   STATUS
+ASM    cp4waiops   aiops-topology   2.5.0     OK
+
+KIND        NAMESPACE   NAME        STATUS       MESSAGE
+AIOpsEdge   cp4waiops   aiopsedge   Configured   all critical components are reporting healthy
+
+KIND      NAMESPACE   NAME               VERSION   STATUS   MESSAGE
+AIOpsUI   cp4waiops   aiopsui-instance   3.3.0     True     Ready
+
+Hint: for a more detailed printout of each operator's components' statuses, run `oc waiops status-all`.
+```
+
+### Detailed installation status checker output (`oc waiops status-all`)
+```
+$ oc waiops status
+
+______________________________________________________________
+Installation instances:
+
+NAMESPACE   NAME                  PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
+cp4waiops   ibm-cp-watson-aiops   Running   Accepted   rook-cephfs    rook-ceph-block          63m
+______________________________________________________________
+ZenService instances:
+
+KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
+ZenService   iaf-zen-cpdservice   cp4waiops   4.4.2     Completed   100%       The Current Operation Is Completed
+______________________________________________________________
+AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
+
+KIND                    NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
+AutomationUIConfig      cp4waiops   iaf-system              1.3.3     True     AutomationUIConfig successfully registered
+AutomationBase          cp4waiops   automationbase-sample   2.0.3     True     AutomationBase instance successfully created
+Cartridge               cp4waiops   cp4waiops-cartridge     1.3.3     True     Cartridge successfully registered
+CartridgeRequirements   cp4waiops   cp4waiops-cartridge     1.3.3     True     CartridgeRequirements successfully registered
 ______________________________________________________________
 IRCore and AIOpsAnalyticsOrchestrator instances:
 
@@ -47,23 +120,10 @@ AIOpsEdge   cp4waiops   aiopsedge   Configured   all critical components are rep
 KIND      NAMESPACE   NAME               VERSION   STATUS   MESSAGE
 AIOpsUI   cp4waiops   aiopsui-instance   3.3.0     True     Ready
 ______________________________________________________________
-AutomationUIConfig, AutomationBase, Cartridge, and CartridgeRequirements instances:
-
-KIND                    NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
-AutomationUIConfig      cp4waiops   iaf-system              1.3.3     True     AutomationUIConfig successfully registered
-AutomationBase          cp4waiops   automationbase-sample   2.0.3     True     AutomationBase instance successfully created
-Cartridge               cp4waiops   cp4waiops-cartridge     1.3.3     True     Cartridge successfully registered
-CartridgeRequirements   cp4waiops   cp4waiops-cartridge     1.3.3     True     CartridgeRequirements successfully registered
-______________________________________________________________
 Kong instances:
 
 KIND   NAMESPACE   NAME      STATUS   MESSAGE
 Kong   cp4waiops   gateway   True     InstallSuccessful
-______________________________________________________________
-ZenService instances:
-
-KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
-ZenService   iaf-zen-cpdservice   cp4waiops   4.4.2     Completed   100%       The Current Operation Is Completed
 ______________________________________________________________
 Vault (VaultDeploy and VaultAccess) instances:
 
@@ -192,7 +252,7 @@ Orchestrator pod current status:
 cp4waiops                                          ibm-aiops-orchestrator-controller-manager-cf876559-jvwz2          1/1     Running       0          64m
 ```
 
-### Upgrade status checker:
+### Upgrade status checker (`oc waiops status-upgrade`):
 ```
 $ oc waiops upgrade-status
 
@@ -259,5 +319,6 @@ chmod +x cp4waiops-samples/kubectl-plugin/kubectl-waiops
 cp cp4waiops-samples/kubectl-plugin/kubectl-waiops /usr/local/bin/kubectl-waiops
 
 oc waiops status
-oc waiops upgrade-status
+oc waiops status-all
+oc waiops status-upgrade
 ```


### PR DESCRIPTION
- Implemented separate installation `status` and `status-all` commands: 
  - `oc waiops status` for a more concise "standard" output
  - `oc waiops status-all` for a more detailed "verbose" output
- Reorganized installation status checker output for both commands listed above
- Added EventProcessor checks for both `status` commands and `status-upgrade`
- Updated docs and script version

Resolves https://github.ibm.com/katamari/dev-issue-tracking/issues/27751