### PR TITLE
[Status checker] Add color coding to `status` and `status-all` commands; update `status-upgrade` to detect install version and check components based on 3.3 or 3.4 instance version

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -252,6 +252,16 @@ then
     fi
 
     echo "______________________________________________________________"
+    echo "Secure Tunnel instances:" && echo ""
+    INSTANCE=$(oc get tunnels.sretooling.management.ibm.com -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Deployed\")].status")
+    STATUS=$(oc get tunnels.sretooling.management.ibm.com -o jsonpath='{.items[].status.versions.status}')
+    if [[ $STATUS == "Ready" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
+    echo "______________________________________________________________"
     echo "CSVs from $INSTALLATION_NAMESPACE namespace:" && echo ""
     INSTANCE=$(oc get csvs -n $INSTALLATION_NAMESPACE) 
 
@@ -731,6 +741,33 @@ then
         fi
     }
 
+    secureTunnelUpgradeStatus() {    
+        INITIALIZED=$(oc get tunnels.sretooling.management.ibm.com -o jsonpath='{.items[].status.conditions[?(@.type=="Initialized")].status}')
+        DEPLOYED=$(oc get tunnels.sretooling.management.ibm.com -o jsonpath='{.items[].status.conditions[?(@.type=="Deployed")].status}')
+        
+        NUM_DEPLOYMENT_OPERATORREPLICAS=$(oc get deployment ibm-secure-tunnel-operator -o jsonpath='{.status.replicas}')
+        NUM_DEPLOYMENT_OPERATORAVAILABLEREPLICAS=$(oc get deployment ibm-secure-tunnel-operator -o jsonpath='{.status.availableReplicas}')
+        
+        NUM_STATEFULSET_REPLICAS=$(oc get statefulset sre-tunnel-controller -o jsonpath='{.status.replicas}')
+        NUM_STATEFULSET_READYREPLICAS=$(oc get statefulset sre-tunnel-controller -o jsonpath='{.status.readyReplicas}')
+        
+        NUM_DEPLOYMENT_NETWORKAPIREPLICAS=$(oc get deployment sre-tunnel-tunnel-network-api -o jsonpath='{.status.replicas}')
+        NUM_DEPLOYMENT_NETWORKAPIAVAILABLEREPLICAS=$(oc get deployment sre-tunnel-tunnel-network-api -o jsonpath='{.status.availableReplicas}')
+        
+        NUM_DEPLOYMENT_TUNNELUIREPLICAS=$(oc get deployment sre-tunnel-tunnel-ui-mcmtunnelui -o jsonpath='{.status.replicas}')
+        NUM_DEPLOYMENT_TUNNELUIAVAILABLEREPLICAS=$(oc get deployment sre-tunnel-tunnel-ui-mcmtunnelui -o jsonpath='{.status.availableReplicas}')
+        
+        DETAILS=$(oc get tunnels.sretooling.management.ibm.com -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Deployed\")].status")
+        if [ "${INITIALIZED}" == "True" ] && [ "${DEPLOYED}" == "True" ] && [ "${NUM_DEPLOYMENT_OPERATORREPLICAS}" == "${NUM_DEPLOYMENT_OPERATORAVAILABLEREPLICAS}" ] && [ "${NUM_STATEFULSET_REPLICAS}" == "${NUM_STATEFULSET_READYREPLICAS}" ] && [ "${NUM_DEPLOYMENT_NETWORKAPIREPLICAS}" == "${NUM_DEPLOYMENT_NETWORKAPIAVAILABLEREPLICAS}" ] && [ "${NUM_DEPLOYMENT_TUNNELUIREPLICAS}" == "${NUM_DEPLOYMENT_TUNNELUIAVAILABLEREPLICAS}" ];
+        then 
+            SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
+            return 0;
+        else 
+            FAILING_UPGRADE+="${newline}${DETAILS}"
+            return 1;
+        fi
+    }
+
     # Check current instance version and component status checks for that version of CP4WAIOps
     if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
     then 
@@ -762,32 +799,33 @@ then
     vaultDeployUpgradeStatus
     vaultAccessUpgradeStatus
     postgresUpgradeStatus
+    secureTunnelUpgradeStatus
     asmUpgradeStatus
     FlinkEventProcessorUpgradeStatus
 
     # Print out results of status checks
     printf "
-${bold}${green}______________________________________________________________
+${normal}______________________________________________________________
 
 The following component(s) have finished upgrading:
-${normal}${SUCCESSFULLY_UPGRADED}
+${green}${SUCCESSFULLY_UPGRADED}
 
-${bold}${green}______________________________________________________________
+${normal}______________________________________________________________
 "
     if [ "$FAILING_UPGRADE" != "" ];
     then 
         printf "
-${bold}${red}______________________________________________________________
+${normal}______________________________________________________________
 
 Meanwhile, the following component(s) have not upgraded yet:
-${normal}${FAILING_UPGRADE}
+${red}${FAILING_UPGRADE}
 
-If only a short time has passed since the upgrade was started, the components may
+${normal}If only a short time has passed since the upgrade was started, the components may
 need more time to complete upgrading. If you have waited a significant amount of time
 and the statuses of the components listed above are not changing, please refer to
 the troubleshooting docs or open a support case.
 
-${bold}${red}______________________________________________________________
+${normal}______________________________________________________________
 ";
     fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -14,9 +14,11 @@ white=$(tput setaf 7)
 bold=$(tput bold)
 normal=$(tput sgr0) #reset color/bolding
 
-# Get installation namespace (gathered from existing installation instance on the cluster)
+# Get installation namespace (gathered from existing installation instance on the cluster) and version
 INSTALLATION_NAME=$(oc get installations.orchestrator.aiops.ibm.com -A --no-headers | while read a b c; do echo "$b"; done;)
 INSTALLATION_NAMESPACE=$(oc get installations.orchestrator.aiops.ibm.com -A --no-headers | while read a b c; do echo "$a"; done;)
+CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-orchestrator)         
+VERSION_AIOPSORCHESTRATOR=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.spec.version}' | awk '{ print substr( $0, 0, 3 ) }')
 
 # optional argument handling
 if [[ "$1" == "version" ]]
@@ -512,6 +514,34 @@ then
 
     oc project ${INSTALLATION_NAMESPACE}
 
+    component-versions-33() {
+        MAJORVERSION_AIOPSUI="3.3"
+        MAJORVERSION_AIMANAGER="2.4"
+        MAJORVERSION_IRCORE="3.3"
+        MAJORVERSION_LIFECYCLESERVICE="3.3"
+        MAJORVERSION_AIOPSANALYTICSORCHESTRATOR="3.2"
+        MAJORVERSION_VAULTDEPLOY="3.3"
+        MAJORVERSION_VAULTACCESS="3.3"
+        MAJORVERSION_POSTGRESERVICE="1.0"
+        MAJORVERSION_POSTGRESDB="1.0"
+        MAJORVERSION_ASM="2.5"
+        MAJORVERSION_FLINKEP="4.0"
+    }
+
+    component-versions-34() {
+        MAJORVERSION_AIOPSUI="3.4"
+        MAJORVERSION_AIMANAGER="2.5"
+        MAJORVERSION_IRCORE="3.4"
+        MAJORVERSION_LIFECYCLESERVICE="3.4"
+        MAJORVERSION_AIOPSANALYTICSORCHESTRATOR="3.4"
+        MAJORVERSION_VAULTDEPLOY="3.4"
+        MAJORVERSION_VAULTACCESS="3.4"
+        MAJORVERSION_POSTGRESERVICE="1.0"
+        MAJORVERSION_POSTGRESDB="1.0"
+        MAJORVERSION_ASM="2.7"
+        MAJORVERSION_FLINKEP="4.0"
+    }
+    
     aiopsEdgeBaseUpgradeStatus() {    
         UPGRADED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.conditions[?(@.type=="UpgradeReady")].status}')
         CONFIGURED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
@@ -529,7 +559,7 @@ then
     aiopsUIUpgradeStatus() {    
         CURRENT_MAJOR_VERSION=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
-        if [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        if [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_AIOPSUI}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -557,7 +587,7 @@ then
         PHASE_STATUS=$(oc get aimanager aimanager -o jsonpath='{.status.phase}')
         CURRENT_MAJOR_VERSION=$(oc get aimanager aimanager -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get AIManager -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message")
-        if [ "${PHASE_STATUS}" == "Completed" ] && [ "${CURRENT_MAJOR_VERSION}" == "2.4" ];
+        if [ "${PHASE_STATUS}" == "Completed" ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_AIMANAGER}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -573,7 +603,7 @@ then
         OBSERVED_GENERATION=$(oc get ircore aiops -o jsonpath='{.status.conditions[].observedGeneration}')        
         CURRENT_MAJOR_VERSION=$(oc get ircore aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get ircore -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
-        if [ "${UPGRADED}" == "True" ] && [ "${OBSERVED_GENERATION}" == ${METADATA_GENERATION} ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        if [ "${UPGRADED}" == "True" ] && [ "${OBSERVED_GENERATION}" == ${METADATA_GENERATION} ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_IRCORE}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -589,7 +619,7 @@ then
         OBSERVED_GENERATION=$(oc get lifecycleservices aiops -o jsonpath='{.status.observedGeneration}')
         CURRENT_MAJOR_VERSION=$(oc get lifecycleservices aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
-        if [ "${UPGRADED}" == "True" ] && [ "${OBSERVED_GENERATION}" == ${METADATA_GENERATION} ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        if [ "${UPGRADED}" == "True" ] && [ "${OBSERVED_GENERATION}" == ${METADATA_GENERATION} ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_LIFECYCLESERVICE}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -605,7 +635,7 @@ then
         OBSERVED_GENERATION=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.observedGeneration}')
         CURRENT_MAJOR_VERSION=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
-        if [ "${UPGRADED}" == "True" ] && [ "${OBSERVED_GENERATION}" == ${METADATA_GENERATION} ] && [ "${CURRENT_MAJOR_VERSION}" == "3.2" ];
+        if [ "${UPGRADED}" == "True" ] && [ "${OBSERVED_GENERATION}" == ${METADATA_GENERATION} ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_AIOPSANALYTICSORCHESTRATOR}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -619,7 +649,7 @@ then
         VAULTDEPLOY_COMPLETED=$(oc get vaultdeploy ibm-vault-deploy -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}')
         CURRENT_MAJOR_VERSION=$(oc get vaultdeploy ibm-vault-deploy -o jsonpath='{.metadata.annotations.productVersion}' | cut -c1-3)
         DETAILS=$(oc get vaultdeploy -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
-        if [ "${VAULTDEPLOY_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        if [ "${VAULTDEPLOY_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_VAULTDEPLOY}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -633,7 +663,7 @@ then
         VAULTACCESS_COMPLETED=$(oc get vaultaccess ibm-vault-access -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}')
         CURRENT_MAJOR_VERSION=$(oc get vaultaccess ibm-vault-access -o jsonpath='{.metadata.annotations.productVersion}' | cut -c1-3)
         DETAILS=$(oc get vaultaccess -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
-        if [ "${VAULTACCESS_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "3.3" ];
+        if [ "${VAULTACCESS_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_VAULTACCESS}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -659,7 +689,7 @@ then
         POSTGRESERVICE_CURRENT_MAJOR_VERSION=$(oc get postgreservices cp4waiops-postgres -o jsonpath='{.spec.version}' | cut -c1-3)
         POSTGRESDB_CURRENT_MAJOR_VERSION=$(oc get postgresdb cp4waiops-postgresdb -o jsonpath='{.spec.version}' | cut -c1-3)
         DETAILS=$(oc get postgreservices,postgresdb -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
-        if [ "${POSTGRESERVICE_COMPLETED}" == "${POSTGRESDB_COMPLETED}" ] && [ "${STATEFULSET_REPLICA_COUNT}" == "${STATEFULSET_CURRENT_REPLICA_COUNT}" ] && [ "${POSTGRES_PROXY_REPLICA_COUNT}" == "${POSTGRES_PROXY_CURRENT_REPLICA_COUNT}" ] && [ "${POSTGRES_SENTINEL_REPLICA_COUNT}" == "${POSTGRES_SENTINEL_CURRENT_REPLICA_COUNT}" ] && [ "${POSTGRESERVICE_CURRENT_MAJOR_VERSION}" == "1.0" ] && [ "${POSTGRESDB_CURRENT_MAJOR_VERSION}" == "1.0" ];
+        if [ "${POSTGRESERVICE_COMPLETED}" == "${POSTGRESDB_COMPLETED}" ] && [ "${STATEFULSET_REPLICA_COUNT}" == "${STATEFULSET_CURRENT_REPLICA_COUNT}" ] && [ "${POSTGRES_PROXY_REPLICA_COUNT}" == "${POSTGRES_PROXY_CURRENT_REPLICA_COUNT}" ] && [ "${POSTGRES_SENTINEL_REPLICA_COUNT}" == "${POSTGRES_SENTINEL_CURRENT_REPLICA_COUNT}" ] && [ "${POSTGRESERVICE_CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_POSTGRESERVICE}" ] && [ "${POSTGRESDB_CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_POSTGRESDB}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -673,7 +703,7 @@ then
         ASM_COMPLETED=$(oc get asm aiops-topology -o jsonpath='{.status.phase}')
         CURRENT_MAJOR_VERSION=$(oc get asm aiops-topology -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase")
-        if [ "${ASM_COMPLETED}" == "OK" ] && [ "${CURRENT_MAJOR_VERSION}" == "2.5" ];
+        if [ "${ASM_COMPLETED}" == "OK" ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_ASM}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -687,7 +717,7 @@ then
         FLINK_EP_COMPLETED=$(oc get EventProcessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
         CURRENT_MAJOR_VERSION=$(oc get EventProcessor cp4waiops-eventprocessor -o jsonpath='{.status.versions.reconciled}' | cut -c1-3)
         DETAILS=$(oc get EventProcessor cp4waiops-eventprocessor -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
-        if [ "${FLINK_EP_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "4.0" ];
+        if [ "${FLINK_EP_COMPLETED}" == "True" ] && [ "${CURRENT_MAJOR_VERSION}" == "${MAJORVERSION_FLINKEP}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;
@@ -697,7 +727,18 @@ then
         fi
     }
 
-    # Run component status checks
+    # Check current instance version and component status checks for that version of CP4WAIOps
+    echo ""
+    echo "${blue}Cloud Pak for Watson AIOps v${VERSION_AIOPSORCHESTRATOR} upgrade status:"
+
+    if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
+    then 
+        component-versions-34
+    elif [ "${VERSION_AIOPSORCHESTRATOR}" == "3.3" ]; 
+    then
+        component-versions-33
+    fi
+
     aiopsEdgeBaseUpgradeStatus
     lifecycleUpgradeStatus
     aiopsUIUpgradeStatus

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -18,11 +18,10 @@ normal=$(tput sgr0) #reset color/bolding
 INSTALLATION_NAME=$(oc get installations.orchestrator.aiops.ibm.com -A --no-headers | while read a b c; do echo "$b"; done;)
 INSTALLATION_NAMESPACE=$(oc get installations.orchestrator.aiops.ibm.com -A --no-headers | while read a b c; do echo "$a"; done;)
 
-
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.6"
+    echo "0.0.7"
     exit 0
 fi
 
@@ -36,36 +35,89 @@ fi
 # optional argument handling
 if [[ "$1" == "status" ]]
 then
+    oc project ${INSTALLATION_NAMESPACE}
+    
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
-    oc get installations.orchestrator.aiops.ibm.com -A 
+    INSTANCE=$(oc get installation aiops-installation)
+    STATUS=$(oc get installation aiops-installation -o jsonpath='{.status.phase}')
+    if [[ $STATUS == "Running" ]]; then
+        printf "$green$INSTANCE$normal\n"
+    else
+        printf "$red$INSTANCE$normal\n"
+    fi
     
     echo "______________________________________________________________"
     echo "ZenService instances:" && echo ""
-    oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+    INSTANCE=$(oc get zenservice iaf-zen-cpdservice -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage')
+    STATUS=$(oc get zenservice iaf-zen-cpdservice -o jsonpath='{.status.zenStatus}')
+    if [[ $STATUS == "Completed" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     echo "______________________________________________________________"
     echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""
-    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
-    
+    INSTANCE=$(oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+    STATUS_AUIC=$(oc get automationuiconfig iaf-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_AB=$(oc get automationbase automationbase-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_IR_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS_AUIC == "True" ]] && [[ $STATUS_AB == "True" ]] && [[ $STATUS_CARTRIDGE == "True" ]] && [[ $STATUS_CARTRIDGE_REQS == "True" ]] && [[ $STATUS_IR_EP == "True" ]] && [[ $STATUS_EP == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
-    oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message"
-    
+    INSTANCE=$(oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    STATUS_IRCORE=$(oc get ircore aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_ANALYTICS_ORCHESTRATOR=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS_IRCORE == "True" ]] && [[ $STATUS_ANALYTICS_ORCHESTRATOR == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "LifecycleService instances:" && echo ""
-    oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message"
-    
+    INSTANCE=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    STATUS=$(oc get lifecycleservice aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "BaseUI instances:" && echo ""
-    oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
-    
+    INSTANCE=$(oc get BaseUI baseui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    STATUS=$(oc get BaseUI baseui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
-    oc get AIManager -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
-    oc get asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
-    oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
-    oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
+    INSTANCE=$(oc get AIManager aimanager -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
+    oc get asm aiops-topology -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
+    oc get aiopsedge aiopsedge -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
+    oc get aiopsui aiopsui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    STATUS_AIMANAGER=$(oc get AIManager aimanager -o jsonpath='{.status.phase}')
+    STATUS_ASM=$(oc get asm aiops-topology -o jsonpath='{.status.phase}')
+    STATUS_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
+    STATUS_AIOPSUI=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS_AIMANAGER == "Completed" ]] && [[ $STATUS_ASM == "OK" ]] && [[ $STATUS_AIOPSEDGE == "Configured" ]] && [[ $STATUS_AIOPSUI == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     printf "
 ${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status-all\`.
@@ -77,77 +129,362 @@ fi
 # optional argument handling
 if [[ "$1" == "status-all" ]]
 then
+    oc project ${INSTALLATION_NAMESPACE}
+
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
-    oc get installations.orchestrator.aiops.ibm.com -A 
+    INSTANCE=$(oc get installation aiops-installation)
+    STATUS=$(oc get installation aiops-installation -o jsonpath='{.status.phase}')
+    if [[ $STATUS == "Running" ]]; then
+        printf "$green$INSTANCE$normal\n"
+    else
+        printf "$red$INSTANCE$normal\n"
+    fi
     
     echo "______________________________________________________________"
     echo "ZenService instances:" && echo ""
-    oc get zenservice -A -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage'
+    INSTANCE=$(oc get zenservice iaf-zen-cpdservice -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage')
+    STATUS=$(oc get zenservice iaf-zen-cpdservice -o jsonpath='{.status.zenStatus}')
+    if [[ $STATUS == "Completed" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     echo "______________________________________________________________"
     echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""
-    oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message'
-    
+    INSTANCE=$(oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+    STATUS_AUIC=$(oc get automationuiconfig iaf-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_AB=$(oc get automationbase automationbase-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_IR_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS_AUIC == "True" ]] && [[ $STATUS_AB == "True" ]] && [[ $STATUS_CARTRIDGE == "True" ]] && [[ $STATUS_CARTRIDGE_REQS == "True" ]] && [[ $STATUS_IR_EP == "True" ]] && [[ $STATUS_EP == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
-    oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message"
-    
+    INSTANCE=$(oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    STATUS_IRCORE=$(oc get ircore aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_ANALYTICS_ORCHESTRATOR=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS_IRCORE == "True" ]] && [[ $STATUS_ANALYTICS_ORCHESTRATOR == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "LifecycleService instances:" && echo ""
-    oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message"
-    
+    INSTANCE=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    STATUS=$(oc get lifecycleservice aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "BaseUI instances:" && echo ""
-    oc get BaseUI -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
-    
+    INSTANCE=$(oc get BaseUI baseui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    STATUS=$(oc get BaseUI baseui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
-    oc get AIManager -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
-    oc get asm -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
-    oc get aiopsedge -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
-    oc get aiopsui -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason"
-    
+    INSTANCE=$(oc get AIManager aimanager -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
+    oc get asm aiops-topology -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
+    oc get aiopsedge aiopsedge -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
+    oc get aiopsui aiopsui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    STATUS_AIMANAGER=$(oc get AIManager aimanager -o jsonpath='{.status.phase}')
+    STATUS_ASM=$(oc get asm aiops-topology -o jsonpath='{.status.phase}')
+    STATUS_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
+    STATUS_AIOPSUI=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [[ $STATUS_AIMANAGER == "Completed" ]] && [[ $STATUS_ASM == "OK" ]] && [[ $STATUS_AIOPSEDGE == "Configured" ]] && [[ $STATUS_AIOPSUI == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "Kong instances:" && echo ""
-    oc get kong -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:.status.conditions[?(@.type==\"Deployed\")].status,MESSAGE:status.conditions[?(@.type==\"Deployed\")].reason"         
-    
+    INSTANCE=$(oc get kong gateway -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:.status.conditions[?(@.type==\"Deployed\")].status,MESSAGE:status.conditions[?(@.type==\"Deployed\")].reason")         
+    STATUS=$(oc get kong gateway -o jsonpath='{.status.conditions[].status}')
+    if [[ $STATUS == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "Vault (VaultDeploy and VaultAccess) instances:" && echo ""
-    oc get vaultdeploy,vaultaccess -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message"
+    INSTANCE=$(oc get vaultdeploy,vaultaccess -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
+    STATUS_VAULTDEPLOY=$(oc get vaultdeploy ibm-vault-deploy -o jsonpath='{.status.conditions[].status}')
+    STATUS_VAULTACCESS=$(oc get vaultaccess ibm-vault-access -o jsonpath='{.status.conditions[].status}')
+    if [[ $STATUS_VAULTDEPLOY == "True" ]] && [[ $STATUS_VAULTACCESS == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     echo "______________________________________________________________"
     echo "Postgres (Postgreservices and PostgresDB) instances:" && echo ""
-    oc get postgreservices,postgresdb -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message"
-    
+    INSTANCE=$(oc get postgreservices,postgresdb -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
+    STATUS_POSTGRESERVICES=$(oc get postgreservices cp4waiops-postgres -o jsonpath='{.status.conditions[].status}')
+    STATUS_POSTGRESDB=$(oc get postgresdb cp4waiops-postgresdb -o jsonpath='{.status.conditions[].status}')
+    if [[ $STATUS_POSTGRESERVICES == "True" ]] && [[ $STATUS_POSTGRESDB == "True" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo "______________________________________________________________"
     echo "CSVs from $INSTALLATION_NAMESPACE namespace:" && echo ""
-    oc get csvs -n $INSTALLATION_NAMESPACE 
+    INSTANCE=$(oc get csvs -n $INSTALLATION_NAMESPACE) 
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep aimanager-operator)         
+    STATUS_AIMANAGER=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep aiopsedge-operator)         
+    STATUS_AIOPSEDGE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep asm-operator)         
+    STATUS_ASM=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep couchdb-operator)         
+    STATUS_COUCHDB=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep elasticsearch-operator)         
+    STATUS_ELASTICSEARCH=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-ir-ai)         
+    STATUS_AIOPSIRAI=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-ir-core)         
+    STATUS_AIOPSIRCORE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-ir-lifecycle)         
+    STATUS_AIOPSIRLIFECYCLE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-orchestrator)         
+    STATUS_AIOPSORCHESTRATOR=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-core)         
+    STATUS_AUTOMATIONCORE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-elastic)         
+    STATUS_ELASTIC=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-eventprocessing)         
+    STATUS_EP=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-flink)         
+    STATUS_FLINK=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation.v)         
+    STATUS_AUTOMATION=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-cloud-databases-redis)         
+    STATUS_REDIS=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-common-service-operator)         
+    STATUS_COMMONSERVICE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-management-kong)         
+    STATUS_KONG=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-postgreservice-operator)         
+    STATUS_POSTGRESERVICE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-secure-tunnel-operator)         
+    STATUS_SECURETUNNEL=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-vault-operator)         
+    STATUS_VAULT=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-watson-aiops-ui-operator)         
+    STATUS_AIOPSUI=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    
+    if [[ $STATUS_AIMANAGER == "Succeeded" ]] && [[ $STATUS_AIOPSEDGE == "Succeeded" ]] && [[ $STATUS_ASM == "Succeeded" ]] && [[ $STATUS_COUCHDB == "Succeeded" ]] && [[ $STATUS_ELASTICSEARCH == "Succeeded" ]] && [[ $STATUS_AIOPSIRAI == "Succeeded" ]] && [[ $STATUS_AIOPSIRCORE == "Succeeded" ]] && [[ $STATUS_AIOPSIRLIFECYCLE == "Succeeded" ]] && [[ $STATUS_AIOPSORCHESTRATOR == "Succeeded" ]] && [[ $STATUS_AUTOMATIONCORE == "Succeeded" ]] && [[ $STATUS_ELASTIC == "Succeeded" ]] && [[ $STATUS_EP == "Succeeded" ]] && [[ $STATUS_FLINK == "Succeeded" ]] && [[ $STATUS_AUTOMATION == "Succeeded" ]] && [[ $STATUS_REDIS == "Succeeded" ]] && [[ $STATUS_COMMONSERVICE == "Succeeded" ]] && [[ $STATUS_KONG == "Succeeded" ]] && [[ $STATUS_POSTGRESERVICE == "Succeeded" ]] && [[ $STATUS_SECURETUNNEL == "Succeeded" ]] && [[ $STATUS_VAULT == "Succeeded" ]] && [[ $STATUS_AIOPSUI == "Succeeded" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     echo "______________________________________________________________"
     echo "CSVs from ibm-common-services namespace:" && echo ""
-    oc get csvs -n ibm-common-services
+    INSTANCE=$(oc get csvs -n ibm-common-services)
+    
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep cloud-native-postgresql)         
+    STATUS_ClOUDNATIVEPOSTGRES=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep elasticsearch-operator)         
+    STATUS_ELASTICSEARCH=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-cert-manager-operator)         
+    STATUS_CERTMANAGER=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-common-service-operator)         
+    STATUS_COMMONSERVICE=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-commonui-operator)         
+    STATUS_COMMONUI=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-crossplane-operator)         
+    STATUS_CROSSPLANE=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-crossplane-provider-kubernetes-operator)         
+    STATUS_CROSSPLANEPROVIDER=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-events-operator)         
+    STATUS_EVENTS=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-iam-operator)         
+    STATUS_IAM=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-ingress-nginx-operator)         
+    STATUS_INGRESS=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-licensing-operator)         
+    STATUS_LICENSING=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-management-ingress-operator)         
+    STATUS_MGMTINGRESS=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-mongodb-operator)         
+    STATUS_MONGODB=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-namespace-scope-operator)         
+    STATUS_NAMESPACESCOPE=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-platform-api-operator)         
+    STATUS_PLATFORMAPI=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-zen-operator)         
+    STATUS_ZEN=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep operand-deployment-lifecycle-manager)         
+    STATUS_ODLM=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+
+    if [[ $STATUS_ClOUDNATIVEPOSTGRES == "Succeeded" ]] && [[ $STATUS_ELASTICSEARCH == "Succeeded" ]] && [[ $STATUS_CERTMANAGER == "Succeeded" ]] && [[ $STATUS_COMMONSERVICE == "Succeeded" ]] && [[ $STATUS_COMMONUI == "Succeeded" ]] && [[ $STATUS_CROSSPLANE == "Succeeded" ]] && [[ $STATUS_CROSSPLANEPROVIDER == "Succeeded" ]] && [[ $STATUS_EVENTS == "Succeeded" ]] && [[ $STATUS_IAM == "Succeeded" ]] && [[ $STATUS_INGRESS == "Succeeded" ]] && [[ $STATUS_LICENSING == "Succeeded" ]] && [[ $STATUS_MGMTINGRESS == "Succeeded" ]] && [[ $STATUS_MONGODB == "Succeeded" ]] && [[ $STATUS_NAMESPACESCOPE == "Succeeded" ]] && [[ $STATUS_PLATFORMAPI == "Succeeded" ]] && [[ $STATUS_ZEN == "Succeeded" ]] && [[ $STATUS_ODLM == "Succeeded" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     echo "______________________________________________________________"
     echo "Subscriptions from $INSTALLATION_NAMESPACE namespace:" && echo ""
-    oc get subscriptions -n $INSTALLATION_NAMESPACE 
+    INSTANCE=$(oc get subscriptions -n $INSTALLATION_NAMESPACE)
+    STATUS_AIMANAGER=$(oc get subscription aimanager-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AIOPSEDGE=$(oc get subscription aiopsedge-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_ASM=$(oc get subscription asm-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_COUCHDB=$(oc get subscription couchdb -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AIOPSORCHESTRATOR=$(oc get subscription ibm-aiops-orchestrator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AUTOMATION=$(oc get subscription ibm-automation -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AUTOMATIONCORE=$(oc get subscription ibm-automation-core-v1.3-iaf-core-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AUTOMATIONELASTIC=$(oc get subscription ibm-automation-elastic-v1.3-iaf-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AUTOMATIONEP=$(oc get subscription ibm-automation-eventprocessing-v1.3-iaf-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AUTOMATIONFLINK=$(oc get subscription ibm-automation-flink-v1.3-iaf-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_COMMONSERVICE=$(oc get subscription ibm-common-service-operator-v3-opencloud-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_KONG=$(oc get subscription ibm-management-kong -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_POSTGRESERVICE=$(oc get subscription ibm-postgreservice-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_SECURETUNNEL=$(oc get subscription ibm-secure-tunnel-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_AIOPSUI=$(oc get subscription ibm-watson-aiops-ui-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_IRAI=$(oc get subscription ir-ai-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_IRCORE=$(oc get subscription ir-core-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_IRLIFECYCLE=$(oc get subscription ir-lifecycle-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_REDIS=$(oc get subscription redis -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_VAULT=$(oc get subscription vault -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    if [[ $STATUS_AIMANAGER == "true" ]] && [[ $STATUS_AIOPSEDGE == "true" ]] && [[ $STATUS_ASM == "true" ]] && [[ $STATUS_COUCHDB == "true" ]] && [[ $STATUS_AIOPSORCHESTRATOR == "true" ]] && [[ $STATUS_AUTOMATION == "true" ]] && [[ $STATUS_AUTOMATIONCORE == "true" ]] && [[ $STATUS_AUTOMATIONELASTIC == "true" ]] && [[ $STATUS_AUTOMATIONEP == "true" ]] && [[ $STATUS_AUTOMATIONFLINK == "true" ]] && [[ $STATUS_COMMONSERVICE == "true" ]] && [[ $STATUS_KONG == "true" ]] && [[ $STATUS_POSTGRESERVICE == "true" ]] && [[ $STATUS_SECURETUNNEL == "true" ]] && [[ $STATUS_AIOPSUI == "true" ]] && [[ $STATUS_IRAI == "true" ]] && [[ $STATUS_IRCORE == "true" ]] && [[ $STATUS_IRLIFECYCLE == "true" ]] && [[ $STATUS_REDIS == "true" ]] && [[ $STATUS_VAULT == "true" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
 
     echo "______________________________________________________________"
     echo "Subscriptions from ibm-common-services namespace:" && echo ""
-    oc get subscriptions -n ibm-common-services
-    
-    echo "______________________________________________________________"
-    echo "OperandRequest instances:" && echo ""
-    oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp"
-    
-    echo "______________________________________________________________"
-    echo "ODLM pod current status:" && echo ""
-    oc get pod -A | grep operand-deployment-lifecycle-manager
+    INSTANCE=$(oc get subscriptions -n ibm-common-services)
+    STATUS_ClOUDNATIVEPOSTGRES=$(oc get subscription cloud-native-postgresql -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_CERTMANAGER=$(oc get subscription ibm-cert-manager-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_COMMONSERVICE=$(oc get subscription ibm-common-service-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_COMMONUI=$(oc get subscription ibm-commonui-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_CROSSPLANE=$(oc get subscription ibm-crossplane-operator-app -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_CROSSPLANEPROVIDER=$(oc get subscription ibm-crossplane-provider-kubernetes-operator-app -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_EVENTS=$(oc get subscription ibm-events-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_IAM=$(oc get subscription ibm-iam-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_INGRESS=$(oc get subscription ibm-ingress-nginx-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_LICENSING=$(oc get subscription ibm-licensing-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_MGMTINGRESS=$(oc get subscription ibm-management-ingress-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_MONGODB=$(oc get subscription ibm-mongodb-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_NAMESPACESCOPE=$(oc get subscription ibm-namespace-scope-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_PLATFORMAPI=$(oc get subscription ibm-platform-api-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_ZEN=$(oc get subscription ibm-zen-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    STATUS_ODLM=$(oc get subscription operand-deployment-lifecycle-manager-app -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
+    if [[ $STATUS_ClOUDNATIVEPOSTGRES == "true" ]] && [[ $STATUS_CERTMANAGER == "true" ]] && [[ $STATUS_COMMONSERVICE == "true" ]] && [[ $STATUS_COMMONUI == "true" ]] && [[ $STATUS_CROSSPLANE == "true" ]] && [[ $STATUS_CROSSPLANEPROVIDER == "true" ]] && [[ $STATUS_EVENTS == "true" ]] && [[ $STATUS_IAM == "true" ]] && [[ $STATUS_INGRESS == "true" ]] && [[ $STATUS_LICENSING == "true" ]] && [[ $STATUS_MGMTINGRESS == "true" ]] && [[ $STATUS_MONGODB == "true" ]] && [[ $STATUS_NAMESPACESCOPE == "true" ]] && [[ $STATUS_PLATFORMAPI == "true" ]] && [[ $STATUS_ZEN == "true" ]] && [[ $STATUS_ODLM == "true" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
 
     echo "______________________________________________________________"
-    echo "Orchestrator pod current status:" && echo ""
-    oc get pod -A | grep ibm-aiops-orchestrator-controller-manager    
-    
+    echo "OperandRequest instances:" && echo ""
+    INSTANCE=$(oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp")
+    STATUS_COMMONUIREQUEST=$(oc get operandrequests ibm-commonui-request -n ibm-common-services -o jsonpath='{.status.phase}')
+    STATUS_IAMREQUEST=$(oc get operandrequests ibm-iam-request -n ibm-common-services -o jsonpath='{.status.phase}')
+    STATUS_MONGODBREQUEST=$(oc get operandrequests ibm-mongodb-request -n ibm-common-services -o jsonpath='{.status.phase}')
+    STATUS_MGMTINGRESSREQUEST=$(oc get operandrequests management-ingress -n ibm-common-services -o jsonpath='{.status.phase}')
+    STATUS_PLATFORMAPIREQUEST=$(oc get operandrequests platform-api-request -n ibm-common-services -o jsonpath='{.status.phase}')
+    STATUS_EDGEBASEREQUEST=$(oc get operandrequests aiopsedge-base -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_EDGECSREQUEST=$(oc get operandrequests aiopsedge-cs -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_IAFCOREREQUEST=$(oc get operandrequests iaf-core-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_IAFEPREQUEST=$(oc get operandrequests iaf-eventprocessing-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_IAFOPERATORREQUEST=$(oc get operandrequests iaf-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_IAFSYSTEMREQUEST=$(oc get operandrequests iaf-system -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_IAFSYSTEMCSREQUEST=$(oc get operandrequests iaf-system-common-service -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_AIOPSAIMANAGERREQUEST=$(oc get operandrequests ibm-aiops-ai-manager -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_AIOPSFOUNDATIONREQUEST=$(oc get operandrequests ibm-aiops-aiops-foundation -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_AIOPSAPPLICATIONMANAGERREQUEST=$(oc get operandrequests ibm-aiops-application-manager -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_AIOPSCONNECTIONREQUEST=$(oc get operandrequests ibm-aiops-connection -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_ELASTICREQUEST=$(oc get operandrequests ibm-elastic-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_IAMSERVICEREQUEST=$(oc get operandrequests ibm-iam-service -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    STATUS_KAFKAUSERREQUEST=$(oc get operandrequests operandrequest-kafkauser-iaf-system -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+
+    if [[ $STATUS_COMMONUIREQUEST == "Running" ]] && [[ $STATUS_IAMREQUEST == "Running" ]] && [[ $STATUS_MONGODBREQUEST == "Running" ]] && [[ $STATUS_MGMTINGRESSREQUEST == "Running" ]] && [[ $STATUS_PLATFORMAPIREQUEST == "Running" ]] && [[ $STATUS_EDGEBASEREQUEST == "Running" ]] && [[ $STATUS_EDGECSREQUEST == "Running" ]] && [[ $STATUS_IAFCOREREQUEST == "Running" ]] && [[ $STATUS_IAFEPREQUEST == "Running" ]] && [[ $STATUS_IAFOPERATORREQUEST == "Running" ]] && [[ $STATUS_IAFSYSTEMREQUEST == "Running" ]] && [[ $STATUS_IAFSYSTEMCSREQUEST == "Running" ]] && [[ $STATUS_AIOPSAIMANAGERREQUEST == "Running" ]] && [[ $STATUS_AIOPSFOUNDATIONREQUEST == "Running" ]] && [[ $STATUS_AIOPSAPPLICATIONMANAGERREQUEST == "Running" ]] && [[ $STATUS_AIOPSCONNECTIONREQUEST == "Running" ]] && [[ $STATUS_ELASTICREQUEST == "Running" ]] && [[ $STATUS_IAMSERVICEREQUEST == "Running" ]] && [[ $STATUS_KAFKAUSERREQUEST == "Running" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
+    echo "______________________________________________________________"
+    echo "ODLM pod current status:" && echo ""
+    INSTANCE=$(oc get pod -A | grep operand-deployment-lifecycle-manager)
+    POD_NAME=$(oc get pods -o name --no-headers=true -n ibm-common-services | grep operand-deployment | awk '{ print substr( $0, 5 ) }')         
+    STATUS=$(oc get pod $POD_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
+    if [[ $STATUS == "Running" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
+    echo "______________________________________________________________"
+    echo "Orchestrator pod current status:" && echo ""   
+    INSTANCE=$(oc get pod -A | grep ibm-aiops-orchestrator-controller-manager)
+    POD_NAME=$(oc get pods -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-orchestrator-controller-manager | awk '{ print substr( $0, 5 ) }')         
+    STATUS=$(oc get pod $POD_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
+    if [[ $STATUS == "Running" ]]; then
+        printf '%s\n' "$green$INSTANCE$normal"
+    else
+        printf '%s\n' "$red$INSTANCE$normal"
+    fi
+
     echo ""
     exit 0
 fi

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -38,6 +38,8 @@ fi
 if [[ "$1" == "status" ]]
 then
     oc project ${INSTALLATION_NAMESPACE}
+    echo ""
+    echo "${blue}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
     
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
@@ -132,6 +134,8 @@ fi
 if [[ "$1" == "status-all" ]]
 then
     oc project ${INSTALLATION_NAMESPACE}
+    echo ""
+    echo "${blue}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
 
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
@@ -729,7 +733,7 @@ then
 
     # Check current instance version and component status checks for that version of CP4WAIOps
     echo ""
-    echo "${blue}Cloud Pak for Watson AIOps v${VERSION_AIOPSORCHESTRATOR} upgrade status:"
+    echo "${blue}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} upgrade status:${normal}"
 
     if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
     then 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -34,6 +34,15 @@ then
     exit 0
 fi
 
+printStatus() {
+    if [[ "$1" == "$2" ]];
+    then
+        printf '%s\n\n' "$green$3$normal"
+    else
+        printf '%s\n\n' "$red$3$normal"
+    fi
+}
+
 # optional argument handling
 if [[ "$1" == "status" ]]
 then
@@ -42,87 +51,100 @@ then
     echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
     
     echo "______________________________________________________________"
+    # Installation status
     echo "Installation instances:" && echo ""
     INSTANCE=$(oc get installations.orchestrator.aiops.ibm.com)
     STATUS=$(oc get installations.orchestrator.aiops.ibm.com -o jsonpath='{.items[].status.phase}')
-    if [[ $STATUS == "Running" ]]; then
-        printf "$green$INSTANCE$normal\n"
-    else
-        printf "$red$INSTANCE$normal\n"
-    fi
+    printStatus "$STATUS" "Running" "$INSTANCE"
     
     echo "______________________________________________________________"
+    # ZenService status
     echo "ZenService instances:" && echo ""
     INSTANCE=$(oc get zenservice iaf-zen-cpdservice -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage')
     STATUS=$(oc get zenservice iaf-zen-cpdservice -o jsonpath='{.status.zenStatus}')
-    if [[ $STATUS == "Completed" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "Completed" "$INSTANCE"
 
     echo "______________________________________________________________"
-    echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""
-    INSTANCE=$(oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+    echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""   
+    # AutomationUIConfig status
+    INSTANCE_AUIC=$(oc get automationuiconfig iaf-system -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_AUIC=$(oc get automationuiconfig iaf-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC"
+
+    # AutomationBase status
+    INSTANCE_AB=$(oc get automationbase automationbase-sample -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_AB=$(oc get automationbase automationbase-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_AB" "True" "$INSTANCE_AB"
+
+    # Cartridge status
+    INSTANCE_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_CARTRIDGE" "True" "$INSTANCE_CARTRIDGE"
+    
+    # CartridgeRequirements status
+    INSTANCE_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_CARTRIDGE_REQS" "True" "$INSTANCE_CARTRIDGE_REQS"
+
+    # aiops-ir-lifecycle EventProcessor status
+    INSTANCE_IR_EP=$(oc get eventprocessor aiops-ir-lifecycle -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_IR_EP=$(oc get eventprocessor aiops-ir-lifecycle -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_IR_EP" "True" "$INSTANCE_IR_EP"
+    
+    # cp4waiops-eventprocessor EventProcessor status
+    INSTANCE_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS_AUIC == "True" ]] && [[ $STATUS_AB == "True" ]] && [[ $STATUS_CARTRIDGE == "True" ]] && [[ $STATUS_CARTRIDGE_REQS == "True" ]] && [[ $STATUS_IR_EP == "True" ]] && [[ $STATUS_EP == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_EP" "True" "$INSTANCE_EP"
 
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
-    INSTANCE=$(oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    # IRCore status
+    INSTANCE_IRCORE=$(oc get ircore aiops  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS_IRCORE=$(oc get ircore aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_IRCORE" "True" "$INSTANCE_IRCORE"
+
+    # AIOpsAnalyticsOrchestrator status
+    INSTANCE_ANALYTICS_ORCHESTRATOR=$(oc get AIOpsAnalyticsOrchestrator aiops  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS_ANALYTICS_ORCHESTRATOR=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS_IRCORE == "True" ]] && [[ $STATUS_ANALYTICS_ORCHESTRATOR == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_ANALYTICS_ORCHESTRATOR" "True" "$INSTANCE_ANALYTICS_ORCHESTRATOR"
 
     echo "______________________________________________________________"
+    # LifecycleService status
     echo "LifecycleService instances:" && echo ""
     INSTANCE=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS=$(oc get lifecycleservice aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "True" "$INSTANCE"
 
     echo "______________________________________________________________"
+    # BaseUI status
     echo "BaseUI instances:" && echo ""
     INSTANCE=$(oc get BaseUI baseui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
     STATUS=$(oc get BaseUI baseui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "True" "$INSTANCE"
 
     echo "______________________________________________________________"
     echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
-    INSTANCE=$(oc get AIManager aimanager -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
-    oc get asm aiops-topology -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
-    oc get aiopsedge aiopsedge -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
-    oc get aiopsui aiopsui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    # AIManager status
+    INSTANCE_AIMANAGER=$(oc get AIManager aimanager -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message")
     STATUS_AIMANAGER=$(oc get AIManager aimanager -o jsonpath='{.status.phase}')
-    STATUS_ASM=$(oc get asm aiops-topology -o jsonpath='{.status.phase}')
-    STATUS_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
-    STATUS_AIOPSUI=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS_AIMANAGER == "Completed" ]] && [[ $STATUS_ASM == "OK" ]] && [[ $STATUS_AIOPSEDGE == "Configured" ]] && [[ $STATUS_AIOPSUI == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_AIMANAGER" "Completed" "$INSTANCE_AIMANAGER"
 
+    # ASM status
+    INSTANCE_ASM=$(oc get asm aiops-topology -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase")
+    STATUS_ASM=$(oc get asm aiops-topology -o jsonpath='{.status.phase}')
+    printStatus "$STATUS_ASM" "OK" "$INSTANCE_ASM"
+
+    # AIOpsEdge status
+    INSTANCE_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    STATUS_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
+    printStatus "$STATUS_AIOPSEDGE" "Configured" "$INSTANCE_AIOPSEDGE"
+
+    # AIOpsUI status
+    INSTANCE_AIOPSUI=$(oc get aiopsui aiopsui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    STATUS_AIOPSUI=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_AIOPSUI" "True" "$INSTANCE_AIOPSUI"
+
+    echo "______________________________________________________________"
     printf "
 ${blue}${bold}Hint: for a more detailed printout of each operator's components' statuses, run \`oc waiops status-all\`.
 ${normal}
@@ -138,357 +160,270 @@ then
     echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
 
     echo "______________________________________________________________"
+    # Installation status-all
     echo "Installation instances:" && echo ""
     INSTANCE=$(oc get installations.orchestrator.aiops.ibm.com)
     STATUS=$(oc get installations.orchestrator.aiops.ibm.com -o jsonpath='{.items[].status.phase}')
-    if [[ $STATUS == "Running" ]]; then
-        printf "$green$INSTANCE$normal\n"
-    else
-        printf "$red$INSTANCE$normal\n"
-    fi
+    printStatus "$STATUS" "Running" "$INSTANCE"
     
     echo "______________________________________________________________"
+    # ZenService status-all
     echo "ZenService instances:" && echo ""
     INSTANCE=$(oc get zenservice iaf-zen-cpdservice -o custom-columns='KIND:.kind,NAME:.metadata.name,NAMESPACE:.metadata.namespace,VERSION:status.currentVersion,STATUS:.status.zenStatus,PROGRESS:.status.Progress,MESSAGE:.status.ProgressMessage')
     STATUS=$(oc get zenservice iaf-zen-cpdservice -o jsonpath='{.status.zenStatus}')
-    if [[ $STATUS == "Completed" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "Completed" "$INSTANCE"
 
     echo "______________________________________________________________"
-    echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""
-    INSTANCE=$(oc get automationuiconfig,automationbase,cartridge,cartridgerequirements,EventProcessor -A -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+    echo "AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:" && echo ""   
+    # AutomationUIConfig status-all
+    INSTANCE_AUIC=$(oc get automationuiconfig iaf-system -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_AUIC=$(oc get automationuiconfig iaf-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC"
+
+    # AutomationBase status-all
+    INSTANCE_AB=$(oc get automationbase automationbase-sample -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_AB=$(oc get automationbase automationbase-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_AB" "True" "$INSTANCE_AB"
+
+    # Cartridge status-all
+    INSTANCE_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_CARTRIDGE" "True" "$INSTANCE_CARTRIDGE"
+    
+    # CartridgeRequirements status-all
+    INSTANCE_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_CARTRIDGE_REQS" "True" "$INSTANCE_CARTRIDGE_REQS"
+
+    # aiops-ir-lifecycle EventProcessor status-all
+    INSTANCE_IR_EP=$(oc get eventprocessor aiops-ir-lifecycle -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_IR_EP=$(oc get eventprocessor aiops-ir-lifecycle -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_IR_EP" "True" "$INSTANCE_IR_EP"
+    
+    # cp4waiops-eventprocessor EventProcessor status-all
+    INSTANCE_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     STATUS_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS_AUIC == "True" ]] && [[ $STATUS_AB == "True" ]] && [[ $STATUS_CARTRIDGE == "True" ]] && [[ $STATUS_CARTRIDGE_REQS == "True" ]] && [[ $STATUS_IR_EP == "True" ]] && [[ $STATUS_EP == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_EP" "True" "$INSTANCE_EP"
 
     echo "______________________________________________________________"
     echo "IRCore and AIOpsAnalyticsOrchestrator instances:" && echo ""
-    INSTANCE=$(oc get ircore,AIOpsAnalyticsOrchestrator -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+    # IRCore status-all
+    INSTANCE_IRCORE=$(oc get ircore aiops  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS_IRCORE=$(oc get ircore aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    printStatus "$STATUS_IRCORE" "True" "$INSTANCE_IRCORE"
+
+    # AIOpsAnalyticsOrchestrator status-all
+    INSTANCE_ANALYTICS_ORCHESTRATOR=$(oc get AIOpsAnalyticsOrchestrator aiops  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS_ANALYTICS_ORCHESTRATOR=$(oc get AIOpsAnalyticsOrchestrator aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS_IRCORE == "True" ]] && [[ $STATUS_ANALYTICS_ORCHESTRATOR == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_ANALYTICS_ORCHESTRATOR" "True" "$INSTANCE_ANALYTICS_ORCHESTRATOR"
 
     echo "______________________________________________________________"
+    # LifecycleService status-all
     echo "LifecycleService instances:" && echo ""
     INSTANCE=$(oc get lifecycleservice -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Lifecycle Service Ready\")].reason,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS=$(oc get lifecycleservice aiops -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "True" "$INSTANCE"
 
     echo "______________________________________________________________"
+    # BaseUI status-all
     echo "BaseUI instances:" && echo ""
     INSTANCE=$(oc get BaseUI baseui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
     STATUS=$(oc get BaseUI baseui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "True" "$INSTANCE"
 
     echo "______________________________________________________________"
     echo "AIManager, ASM, AIOpsEdge, and AIOpsUI instances:" && echo ""
-    INSTANCE=$(oc get AIManager aimanager -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message" && echo ""
-    oc get asm aiops-topology -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase" && echo ""
-    oc get aiopsedge aiopsedge -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message" && echo ""
-    oc get aiopsui aiopsui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
+    # AIManager status-all
+    INSTANCE_AIMANAGER=$(oc get AIManager aimanager -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase,MESSAGE:status.message")
     STATUS_AIMANAGER=$(oc get AIManager aimanager -o jsonpath='{.status.phase}')
+    printStatus "$STATUS_AIMANAGER" "Completed" "$INSTANCE_AIMANAGER"
+
+    # ASM status-all
+    INSTANCE_ASM=$(oc get asm aiops-topology -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.phase")
     STATUS_ASM=$(oc get asm aiops-topology -o jsonpath='{.status.phase}')
+    printStatus "$STATUS_ASM" "OK" "$INSTANCE_ASM"
+
+    # AIOpsEdge status-all
+    INSTANCE_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
     STATUS_AIOPSEDGE=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
+    printStatus "$STATUS_AIOPSEDGE" "Configured" "$INSTANCE_AIOPSEDGE"
+
+    # AIOpsUI status-all
+    INSTANCE_AIOPSUI=$(oc get aiopsui aiopsui-instance -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:status.versions.reconciled,STATUS:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].reason")
     STATUS_AIOPSUI=$(oc get aiopsui aiopsui-instance -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ $STATUS_AIMANAGER == "Completed" ]] && [[ $STATUS_ASM == "OK" ]] && [[ $STATUS_AIOPSEDGE == "Configured" ]] && [[ $STATUS_AIOPSUI == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_AIOPSUI" "True" "$INSTANCE_AIOPSUI"
 
     echo "______________________________________________________________"
+    # Kong status-all
     echo "Kong instances:" && echo ""
     INSTANCE=$(oc get kong gateway -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:.status.conditions[?(@.type==\"Deployed\")].status,MESSAGE:status.conditions[?(@.type==\"Deployed\")].reason")         
     STATUS=$(oc get kong gateway -o jsonpath='{.status.conditions[].status}')
-    if [[ $STATUS == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "True" "$INSTANCE"
 
     echo "______________________________________________________________"
     echo "Vault (VaultDeploy and VaultAccess) instances:" && echo ""
-    INSTANCE=$(oc get vaultdeploy,vaultaccess -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
+    # VaultDeploy status-all
+    INSTANCE_VAULTDEPLOY=$(oc get vaultdeploy ibm-vault-deploy -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
     STATUS_VAULTDEPLOY=$(oc get vaultdeploy ibm-vault-deploy -o jsonpath='{.status.conditions[].status}')
+    printStatus "$STATUS_VAULTDEPLOY" "True" "$INSTANCE_VAULTDEPLOY"
+
+    # VaultAccess status-all
+    INSTANCE_VAULTACCESS=$(oc get vaultaccess ibm-vault-access -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:metadata.annotations.productVersion,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
     STATUS_VAULTACCESS=$(oc get vaultaccess ibm-vault-access -o jsonpath='{.status.conditions[].status}')
-    if [[ $STATUS_VAULTDEPLOY == "True" ]] && [[ $STATUS_VAULTACCESS == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_VAULTACCESS" "True" "$INSTANCE_VAULTACCESS"
 
     echo "______________________________________________________________"
-    echo "Postgres (Postgreservices and PostgresDB) instances:" && echo ""
-    INSTANCE=$(oc get postgreservices,postgresdb -A  -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
+    echo "Postgres (Postgreservices and PostgresDB) instances:" && echo ""  
+    # Postgreservices status-all
+    INSTANCE_POSTGRESERVICES=$(oc get postgreservices cp4waiops-postgres -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
     STATUS_POSTGRESERVICES=$(oc get postgreservices cp4waiops-postgres -o jsonpath='{.status.conditions[].status}')
+    printStatus "$STATUS_POSTGRESERVICES" "True" "$INSTANCE_POSTGRESERVICES"
+
+    # PostgresDB status-all
+    INSTANCE_POSTGRESDB=$(oc get postgresdb cp4waiops-postgresdb -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
     STATUS_POSTGRESDB=$(oc get postgresdb cp4waiops-postgresdb -o jsonpath='{.status.conditions[].status}')
-    if [[ $STATUS_POSTGRESERVICES == "True" ]] && [[ $STATUS_POSTGRESDB == "True" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS_POSTGRESDB" "True" "$INSTANCE_POSTGRESDB"
 
     echo "______________________________________________________________"
+    # Secure Tunnel status-all
     echo "Secure Tunnel instances:" && echo ""
     INSTANCE=$(oc get tunnels.sretooling.management.ibm.com -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Deployed\")].status")
     STATUS=$(oc get tunnels.sretooling.management.ibm.com -o jsonpath='{.items[].status.versions.status}')
-    if [[ $STATUS == "Ready" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    printStatus "$STATUS" "Ready" "$INSTANCE"
 
+    getCSVStatus () {
+        CSV_NAME=$(oc get csvs -o name --no-headers=true -n $1 | grep $2)   
+        INSTANCE=$(oc get $CSV_NAME -n $1)                    
+        STATUS=$(oc get $CSV_NAME -n $1 -o jsonpath='{.status.phase}')
+        printStatus "$STATUS" "Succeeded" "$INSTANCE"
+    }
+    
     echo "______________________________________________________________"
     echo "CSVs from $INSTALLATION_NAMESPACE namespace:" && echo ""
-    INSTANCE=$(oc get csvs -n $INSTALLATION_NAMESPACE) 
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep aimanager-operator)         
-    STATUS_AIMANAGER=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep aiopsedge-operator)         
-    STATUS_AIOPSEDGE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
     
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep asm-operator)         
-    STATUS_ASM=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep couchdb-operator)         
-    STATUS_COUCHDB=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep elasticsearch-operator)         
-    STATUS_ELASTICSEARCH=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-ir-ai)         
-    STATUS_AIOPSIRAI=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-ir-core)         
-    STATUS_AIOPSIRCORE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-ir-lifecycle)         
-    STATUS_AIOPSIRLIFECYCLE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-aiops-orchestrator)         
-    STATUS_AIOPSORCHESTRATOR=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-core)         
-    STATUS_AUTOMATIONCORE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-elastic)         
-    STATUS_ELASTIC=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-eventprocessing)         
-    STATUS_EP=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-flink)         
-    STATUS_FLINK=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation.v)         
-    STATUS_AUTOMATION=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-cloud-databases-redis)         
-    STATUS_REDIS=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-common-service-operator)         
-    STATUS_COMMONSERVICE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-management-kong)         
-    STATUS_KONG=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-postgreservice-operator)         
-    STATUS_POSTGRESERVICE=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-secure-tunnel-operator)         
-    STATUS_SECURETUNNEL=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-vault-operator)         
-    STATUS_VAULT=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-watson-aiops-ui-operator)         
-    STATUS_AIOPSUI=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    
-    if [[ $STATUS_AIMANAGER == "Succeeded" ]] && [[ $STATUS_AIOPSEDGE == "Succeeded" ]] && [[ $STATUS_ASM == "Succeeded" ]] && [[ $STATUS_COUCHDB == "Succeeded" ]] && [[ $STATUS_ELASTICSEARCH == "Succeeded" ]] && [[ $STATUS_AIOPSIRAI == "Succeeded" ]] && [[ $STATUS_AIOPSIRCORE == "Succeeded" ]] && [[ $STATUS_AIOPSIRLIFECYCLE == "Succeeded" ]] && [[ $STATUS_AIOPSORCHESTRATOR == "Succeeded" ]] && [[ $STATUS_AUTOMATIONCORE == "Succeeded" ]] && [[ $STATUS_ELASTIC == "Succeeded" ]] && [[ $STATUS_EP == "Succeeded" ]] && [[ $STATUS_FLINK == "Succeeded" ]] && [[ $STATUS_AUTOMATION == "Succeeded" ]] && [[ $STATUS_REDIS == "Succeeded" ]] && [[ $STATUS_COMMONSERVICE == "Succeeded" ]] && [[ $STATUS_KONG == "Succeeded" ]] && [[ $STATUS_POSTGRESERVICE == "Succeeded" ]] && [[ $STATUS_SECURETUNNEL == "Succeeded" ]] && [[ $STATUS_VAULT == "Succeeded" ]] && [[ $STATUS_AIOPSUI == "Succeeded" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    getCSVStatus "$INSTALLATION_NAMESPACE" "aimanager-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "aiopsedge-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "asm-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "couchdb-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "elasticsearch-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-ir-ai"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-ir-core"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-ir-lifecycle"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-orchestrator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-automation-core"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-automation-elastic"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-automation-eventprocessing"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-automation-flink"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-automation.v"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-cloud-databases-redis"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-common-service-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-management-kong"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-postgreservice-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-secure-tunnel-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-vault-operator"
+    getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-watson-aiops-ui-operator"
 
     echo "______________________________________________________________"
     echo "CSVs from ibm-common-services namespace:" && echo ""
-    INSTANCE=$(oc get csvs -n ibm-common-services)
+
+    getCSVStatus "ibm-common-services" "cloud-native-postgresql"
+    getCSVStatus "ibm-common-services" "elasticsearch-operator"
+    getCSVStatus "ibm-common-services" "ibm-cert-manager-operator"
+    getCSVStatus "ibm-common-services" "ibm-common-service-operator"
+    getCSVStatus "ibm-common-services" "ibm-commonui-operator"
+    getCSVStatus "ibm-common-services" "ibm-crossplane-operator"
+    getCSVStatus "ibm-common-services" "ibm-crossplane-provider-kubernetes-operator"
+    getCSVStatus "ibm-common-services" "ibm-events-operator"
+    getCSVStatus "ibm-common-services" "ibm-iam-operator"
+    getCSVStatus "ibm-common-services" "ibm-ingress-nginx-operator"
+    getCSVStatus "ibm-common-services" "ibm-licensing-operator"
+    getCSVStatus "ibm-common-services" "ibm-management-ingress-operator"
+    getCSVStatus "ibm-common-services" "ibm-mongodb-operator"
+    getCSVStatus "ibm-common-services" "ibm-namespace-scope-operator"
+    getCSVStatus "ibm-common-services" "ibm-platform-api-operator"
+    getCSVStatus "ibm-common-services" "ibm-zen-operator"
+    getCSVStatus "ibm-common-services" "operand-deployment-lifecycle-manager"
+
+    getSubscriptionStatus () {
+        INSTANCE=$(oc get subscription $1 -n $2)                    
+        STATUS=$(oc get subscription $1 -n $2 -o jsonpath='{.status.catalogHealth[].healthy}')
+        printStatus "$STATUS" "true" "$INSTANCE"
+    }
+
+    getSubscriptionStatusGrep () {
+        SUBSCRIPTION=$(oc get subscription -o name --no-headers=true -n $2 | grep $1)   
+        INSTANCE=$(oc get $SUBSCRIPTION -n $2)                    
+        STATUS=$(oc get $SUBSCRIPTION -n $2 -o jsonpath='{.status.catalogHealth[].healthy}')
+        printStatus "$STATUS" "true" "$INSTANCE"
+    }
     
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep cloud-native-postgresql)         
-    STATUS_ClOUDNATIVEPOSTGRES=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep elasticsearch-operator)         
-    STATUS_ELASTICSEARCH=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-cert-manager-operator)         
-    STATUS_CERTMANAGER=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-common-service-operator)         
-    STATUS_COMMONSERVICE=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-commonui-operator)         
-    STATUS_COMMONUI=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-crossplane-operator)         
-    STATUS_CROSSPLANE=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-crossplane-provider-kubernetes-operator)         
-    STATUS_CROSSPLANEPROVIDER=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-events-operator)         
-    STATUS_EVENTS=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-iam-operator)         
-    STATUS_IAM=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-ingress-nginx-operator)         
-    STATUS_INGRESS=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-licensing-operator)         
-    STATUS_LICENSING=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-management-ingress-operator)         
-    STATUS_MGMTINGRESS=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-mongodb-operator)         
-    STATUS_MONGODB=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-namespace-scope-operator)         
-    STATUS_NAMESPACESCOPE=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-platform-api-operator)         
-    STATUS_PLATFORMAPI=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep ibm-zen-operator)         
-    STATUS_ZEN=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    CSV_NAME=$(oc get csvs -o name --no-headers=true -n ibm-common-services | grep operand-deployment-lifecycle-manager)         
-    STATUS_ODLM=$(oc get $CSV_NAME -n ibm-common-services -o jsonpath='{.status.phase}')
-
-    if [[ $STATUS_ClOUDNATIVEPOSTGRES == "Succeeded" ]] && [[ $STATUS_ELASTICSEARCH == "Succeeded" ]] && [[ $STATUS_CERTMANAGER == "Succeeded" ]] && [[ $STATUS_COMMONSERVICE == "Succeeded" ]] && [[ $STATUS_COMMONUI == "Succeeded" ]] && [[ $STATUS_CROSSPLANE == "Succeeded" ]] && [[ $STATUS_CROSSPLANEPROVIDER == "Succeeded" ]] && [[ $STATUS_EVENTS == "Succeeded" ]] && [[ $STATUS_IAM == "Succeeded" ]] && [[ $STATUS_INGRESS == "Succeeded" ]] && [[ $STATUS_LICENSING == "Succeeded" ]] && [[ $STATUS_MGMTINGRESS == "Succeeded" ]] && [[ $STATUS_MONGODB == "Succeeded" ]] && [[ $STATUS_NAMESPACESCOPE == "Succeeded" ]] && [[ $STATUS_PLATFORMAPI == "Succeeded" ]] && [[ $STATUS_ZEN == "Succeeded" ]] && [[ $STATUS_ODLM == "Succeeded" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
-
     echo "______________________________________________________________"
     echo "Subscriptions from $INSTALLATION_NAMESPACE namespace:" && echo ""
-    INSTANCE=$(oc get subscriptions -n $INSTALLATION_NAMESPACE)
-    STATUS_AIMANAGER=$(oc get subscription aimanager-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AIOPSEDGE=$(oc get subscription aiopsedge-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_ASM=$(oc get subscription asm-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_COUCHDB=$(oc get subscription couchdb -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AIOPSORCHESTRATOR=$(oc get subscription ibm-aiops-orchestrator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AUTOMATION=$(oc get subscription ibm-automation -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    getSubscriptionStatus "aimanager-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "aiopsedge-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "asm-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "couchdb" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ibm-aiops-orchestrator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ibm-automation" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatusGrep "ibm-automation-core" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatusGrep "ibm-automation-elastic" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatusGrep "ibm-automation-eventprocessing" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatusGrep "ibm-automation-flink" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatusGrep "ibm-common-service-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ibm-management-kong" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ibm-postgreservice-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ibm-secure-tunnel-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ibm-watson-aiops-ui-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ir-ai-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ir-core-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "ir-lifecycle-operator" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "redis" "$INSTALLATION_NAMESPACE" 
+    getSubscriptionStatus "vault" "$INSTALLATION_NAMESPACE" 
     
-    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-core)
-    STATUS_AUTOMATIONCORE=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    
-    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-elastic)
-    STATUS_AUTOMATIONELASTIC=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    
-    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-eventprocessing)
-    STATUS_AUTOMATIONEP=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    
-    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-flink)
-    STATUS_AUTOMATIONFLINK=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    
-    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-common-service-operator)
-    STATUS_COMMONSERVICE=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-
-    STATUS_KONG=$(oc get subscription ibm-management-kong -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_POSTGRESERVICE=$(oc get subscription ibm-postgreservice-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_SECURETUNNEL=$(oc get subscription ibm-secure-tunnel-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AIOPSUI=$(oc get subscription ibm-watson-aiops-ui-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_IRAI=$(oc get subscription ir-ai-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_IRCORE=$(oc get subscription ir-core-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_IRLIFECYCLE=$(oc get subscription ir-lifecycle-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_REDIS=$(oc get subscription redis -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_VAULT=$(oc get subscription vault -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    if [[ $STATUS_AIMANAGER == "true" ]] && [[ $STATUS_AIOPSEDGE == "true" ]] && [[ $STATUS_ASM == "true" ]] && [[ $STATUS_COUCHDB == "true" ]] && [[ $STATUS_AIOPSORCHESTRATOR == "true" ]] && [[ $STATUS_AUTOMATION == "true" ]] && [[ $STATUS_AUTOMATIONCORE == "true" ]] && [[ $STATUS_AUTOMATIONELASTIC == "true" ]] && [[ $STATUS_AUTOMATIONEP == "true" ]] && [[ $STATUS_AUTOMATIONFLINK == "true" ]] && [[ $STATUS_COMMONSERVICE == "true" ]] && [[ $STATUS_KONG == "true" ]] && [[ $STATUS_POSTGRESERVICE == "true" ]] && [[ $STATUS_SECURETUNNEL == "true" ]] && [[ $STATUS_AIOPSUI == "true" ]] && [[ $STATUS_IRAI == "true" ]] && [[ $STATUS_IRCORE == "true" ]] && [[ $STATUS_IRLIFECYCLE == "true" ]] && [[ $STATUS_REDIS == "true" ]] && [[ $STATUS_VAULT == "true" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
-
-
     echo "______________________________________________________________"
     echo "Subscriptions from ibm-common-services namespace:" && echo ""
-    INSTANCE=$(oc get subscriptions -n ibm-common-services)
-    STATUS_ClOUDNATIVEPOSTGRES=$(oc get subscription cloud-native-postgresql -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_CERTMANAGER=$(oc get subscription ibm-cert-manager-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_COMMONSERVICE=$(oc get subscription ibm-common-service-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_COMMONUI=$(oc get subscription ibm-commonui-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_CROSSPLANE=$(oc get subscription ibm-crossplane-operator-app -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_CROSSPLANEPROVIDER=$(oc get subscription ibm-crossplane-provider-kubernetes-operator-app -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_EVENTS=$(oc get subscription ibm-events-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_IAM=$(oc get subscription ibm-iam-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_INGRESS=$(oc get subscription ibm-ingress-nginx-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_LICENSING=$(oc get subscription ibm-licensing-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_MGMTINGRESS=$(oc get subscription ibm-management-ingress-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_MONGODB=$(oc get subscription ibm-mongodb-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_NAMESPACESCOPE=$(oc get subscription ibm-namespace-scope-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_PLATFORMAPI=$(oc get subscription ibm-platform-api-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_ZEN=$(oc get subscription ibm-zen-operator -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_ODLM=$(oc get subscription operand-deployment-lifecycle-manager-app -n ibm-common-services -o jsonpath='{.status.catalogHealth[].healthy}')
-    if [[ $STATUS_ClOUDNATIVEPOSTGRES == "true" ]] && [[ $STATUS_CERTMANAGER == "true" ]] && [[ $STATUS_COMMONSERVICE == "true" ]] && [[ $STATUS_COMMONUI == "true" ]] && [[ $STATUS_CROSSPLANE == "true" ]] && [[ $STATUS_CROSSPLANEPROVIDER == "true" ]] && [[ $STATUS_EVENTS == "true" ]] && [[ $STATUS_IAM == "true" ]] && [[ $STATUS_INGRESS == "true" ]] && [[ $STATUS_LICENSING == "true" ]] && [[ $STATUS_MGMTINGRESS == "true" ]] && [[ $STATUS_MONGODB == "true" ]] && [[ $STATUS_NAMESPACESCOPE == "true" ]] && [[ $STATUS_PLATFORMAPI == "true" ]] && [[ $STATUS_ZEN == "true" ]] && [[ $STATUS_ODLM == "true" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    getSubscriptionStatus "cloud-native-postgresql" "ibm-common-services" 
+    getSubscriptionStatus "ibm-cert-manager-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-common-service-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-commonui-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-crossplane-operator-app" "ibm-common-services" 
+    getSubscriptionStatus "ibm-crossplane-provider-kubernetes-operator-app" "ibm-common-services" 
+    getSubscriptionStatus "ibm-events-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-iam-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-ingress-nginx-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-licensing-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-management-ingress-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-mongodb-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-namespace-scope-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-platform-api-operator" "ibm-common-services" 
+    getSubscriptionStatus "ibm-zen-operator" "ibm-common-services" 
+    getSubscriptionStatus "operand-deployment-lifecycle-manager-app" "ibm-common-services" 
 
+    getOperandRequestStatus () {
+        INSTANCE=$(oc get operandrequests $1 -n $2 -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp")                    
+        STATUS=$(oc get operandrequests $1 -n $2 -o jsonpath='{.status.phase}')
+        printStatus "$STATUS" "Running" "$INSTANCE"
+    }
     echo "______________________________________________________________"
     echo "OperandRequest instances:" && echo ""
-    INSTANCE=$(oc get operandrequests -A -o custom-columns="NAMESPACE:metadata.namespace,NAME:metadata.name,PHASE:status.phase,CREATED AT:metadata.creationTimestamp")
-    STATUS_COMMONUIREQUEST=$(oc get operandrequests ibm-commonui-request -n ibm-common-services -o jsonpath='{.status.phase}')
-    STATUS_IAMREQUEST=$(oc get operandrequests ibm-iam-request -n ibm-common-services -o jsonpath='{.status.phase}')
-    STATUS_MONGODBREQUEST=$(oc get operandrequests ibm-mongodb-request -n ibm-common-services -o jsonpath='{.status.phase}')
-    STATUS_MGMTINGRESSREQUEST=$(oc get operandrequests management-ingress -n ibm-common-services -o jsonpath='{.status.phase}')
-    STATUS_PLATFORMAPIREQUEST=$(oc get operandrequests platform-api-request -n ibm-common-services -o jsonpath='{.status.phase}')
-    STATUS_EDGEBASEREQUEST=$(oc get operandrequests aiopsedge-base -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_EDGECSREQUEST=$(oc get operandrequests aiopsedge-cs -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_IAFCOREREQUEST=$(oc get operandrequests iaf-core-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_IAFEPREQUEST=$(oc get operandrequests iaf-eventprocessing-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_IAFOPERATORREQUEST=$(oc get operandrequests iaf-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_IAFSYSTEMREQUEST=$(oc get operandrequests iaf-system -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_IAFSYSTEMCSREQUEST=$(oc get operandrequests iaf-system-common-service -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_AIOPSAIMANAGERREQUEST=$(oc get operandrequests ibm-aiops-ai-manager -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_AIOPSFOUNDATIONREQUEST=$(oc get operandrequests ibm-aiops-aiops-foundation -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_AIOPSAPPLICATIONMANAGERREQUEST=$(oc get operandrequests ibm-aiops-application-manager -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_AIOPSCONNECTIONREQUEST=$(oc get operandrequests ibm-aiops-connection -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_ELASTICREQUEST=$(oc get operandrequests ibm-elastic-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_IAMSERVICEREQUEST=$(oc get operandrequests ibm-iam-service -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-    STATUS_KAFKAUSERREQUEST=$(oc get operandrequests operandrequest-kafkauser-iaf-system -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.phase}')
-
-    if [[ $STATUS_COMMONUIREQUEST == "Running" ]] && [[ $STATUS_IAMREQUEST == "Running" ]] && [[ $STATUS_MONGODBREQUEST == "Running" ]] && [[ $STATUS_MGMTINGRESSREQUEST == "Running" ]] && [[ $STATUS_PLATFORMAPIREQUEST == "Running" ]] && [[ $STATUS_EDGEBASEREQUEST == "Running" ]] && [[ $STATUS_EDGECSREQUEST == "Running" ]] && [[ $STATUS_IAFCOREREQUEST == "Running" ]] && [[ $STATUS_IAFEPREQUEST == "Running" ]] && [[ $STATUS_IAFOPERATORREQUEST == "Running" ]] && [[ $STATUS_IAFSYSTEMREQUEST == "Running" ]] && [[ $STATUS_IAFSYSTEMCSREQUEST == "Running" ]] && [[ $STATUS_AIOPSAIMANAGERREQUEST == "Running" ]] && [[ $STATUS_AIOPSFOUNDATIONREQUEST == "Running" ]] && [[ $STATUS_AIOPSAPPLICATIONMANAGERREQUEST == "Running" ]] && [[ $STATUS_AIOPSCONNECTIONREQUEST == "Running" ]] && [[ $STATUS_ELASTICREQUEST == "Running" ]] && [[ $STATUS_IAMSERVICEREQUEST == "Running" ]] && [[ $STATUS_KAFKAUSERREQUEST == "Running" ]]; then
-        printf '%s\n' "$green$INSTANCE$normal"
-    else
-        printf '%s\n' "$red$INSTANCE$normal"
-    fi
+    getOperandRequestStatus "ibm-commonui-request" "ibm-common-services" 
+    getOperandRequestStatus "ibm-iam-request" "ibm-common-services" 
+    getOperandRequestStatus "ibm-mongodb-request" "ibm-common-services" 
+    getOperandRequestStatus "management-ingress" "ibm-common-services" 
+    getOperandRequestStatus "platform-api-request" "ibm-common-services" 
+    getOperandRequestStatus "aiopsedge-base" "$INSTALLATION_NAMESPACE"  
+    getOperandRequestStatus "aiopsedge-cs" "$INSTALLATION_NAMESPACE"  
+    getOperandRequestStatus "iaf-core-operator" "$INSTALLATION_NAMESPACE"  
+    getOperandRequestStatus "iaf-eventprocessing-operator" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "iaf-operator" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "iaf-system" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "iaf-system-common-service" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "ibm-aiops-ai-manager" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "ibm-aiops-aiops-foundation" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "ibm-aiops-connection" "$INSTALLATION_NAMESPACE"  
+    getOperandRequestStatus "ibm-elastic-operator" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "ibm-iam-service" "$INSTALLATION_NAMESPACE" 
+    getOperandRequestStatus "operandrequest-kafkauser-iaf-system" "$INSTALLATION_NAMESPACE" 
 
     echo "______________________________________________________________"
     echo "ODLM pod current status:" && echo ""

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -545,7 +545,7 @@ then
         MAJORVERSION_ASM="2.7"
         MAJORVERSION_FLINKEP="4.0"
     }
-    
+
     aiopsEdgeBaseUpgradeStatus() {    
         UPGRADED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.conditions[?(@.type=="UpgradeReady")].status}')
         CONFIGURED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
@@ -744,7 +744,7 @@ then
         component-versions-34
         echo ""
         echo "${red}${bold}NOTE: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be an internal dev version (v${VERSION_AIOPSORCHESTRATOR})."
-        echo "      The upgrade-status command checks the status of upgrades to v3.3 and v3.4 only." 
+        echo "      The status-upgrade command checks the status of upgrades to v3.3 and v3.4 only." 
         echo "      Therefore, the upgrade checks below will be against v3.4 component versions."
         echo "      This may influence your results below if your dev build is not based on release-3.4.${normal}"
     fi

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -403,6 +403,7 @@ then
     
     SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-common-service-operator)
     STATUS_COMMONSERVICE=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+
     STATUS_KONG=$(oc get subscription ibm-management-kong -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_POSTGRESERVICE=$(oc get subscription ibm-postgreservice-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_SECURETUNNEL=$(oc get subscription ibm-secure-tunnel-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -23,7 +23,7 @@ VERSION_AIOPSORCHESTRATOR=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonp
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.7"
+    echo "0.0.8"
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -39,7 +39,7 @@ if [[ "$1" == "status" ]]
 then
     oc project ${INSTALLATION_NAMESPACE}
     echo ""
-    echo "${blue}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
+    echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
     
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
@@ -135,7 +135,7 @@ if [[ "$1" == "status-all" ]]
 then
     oc project ${INSTALLATION_NAMESPACE}
     echo ""
-    echo "${blue}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
+    echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} installation status:${normal}"
 
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -388,11 +388,21 @@ then
     STATUS_COUCHDB=$(oc get subscription couchdb -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_AIOPSORCHESTRATOR=$(oc get subscription ibm-aiops-orchestrator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_AUTOMATION=$(oc get subscription ibm-automation -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AUTOMATIONCORE=$(oc get subscription ibm-automation-core-v1.3-iaf-core-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AUTOMATIONELASTIC=$(oc get subscription ibm-automation-elastic-v1.3-iaf-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AUTOMATIONEP=$(oc get subscription ibm-automation-eventprocessing-v1.3-iaf-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_AUTOMATIONFLINK=$(oc get subscription ibm-automation-flink-v1.3-iaf-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
-    STATUS_COMMONSERVICE=$(oc get subscription ibm-common-service-operator-v3-opencloud-operators-openshift-marketplace -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    
+    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-core)
+    STATUS_AUTOMATIONCORE=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    
+    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-elastic)
+    STATUS_AUTOMATIONELASTIC=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    
+    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-eventprocessing)
+    STATUS_AUTOMATIONEP=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    
+    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-automation-flink)
+    STATUS_AUTOMATIONFLINK=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
+    
+    SUBSCRIPTION_NAME=$(oc get subscription -o name --no-headers=true -n $INSTALLATION_NAMESPACE | grep ibm-common-service-operator)
+    STATUS_COMMONSERVICE=$(oc get $SUBSCRIPTION_NAME -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_KONG=$(oc get subscription ibm-management-kong -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_POSTGRESERVICE=$(oc get subscription ibm-postgreservice-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')
     STATUS_SECURETUNNEL=$(oc get subscription ibm-secure-tunnel-operator -n $INSTALLATION_NAMESPACE -o jsonpath='{.status.catalogHealth[].healthy}')

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -43,8 +43,8 @@ then
     
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
-    INSTANCE=$(oc get installation aiops-installation)
-    STATUS=$(oc get installation aiops-installation -o jsonpath='{.status.phase}')
+    INSTANCE=$(oc get installations.orchestrator.aiops.ibm.com)
+    STATUS=$(oc get installations.orchestrator.aiops.ibm.com -o jsonpath='{.items[].status.phase}')
     if [[ $STATUS == "Running" ]]; then
         printf "$green$INSTANCE$normal\n"
     else
@@ -139,8 +139,8 @@ then
 
     echo "______________________________________________________________"
     echo "Installation instances:" && echo ""
-    INSTANCE=$(oc get installation aiops-installation)
-    STATUS=$(oc get installation aiops-installation -o jsonpath='{.status.phase}')
+    INSTANCE=$(oc get installations.orchestrator.aiops.ibm.com)
+    STATUS=$(oc get installations.orchestrator.aiops.ibm.com -o jsonpath='{.items[].status.phase}')
     if [[ $STATUS == "Running" ]]; then
         printf "$green$INSTANCE$normal\n"
     else

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -23,7 +23,7 @@ VERSION_AIOPSORCHESTRATOR=$(oc get $CSV_NAME -n $INSTALLATION_NAMESPACE -o jsonp
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.8"
+    echo "0.0.7"
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -683,9 +683,6 @@ then
         NUM_DEPLOYMENT_OPERATORREPLICAS=$(oc get deployment ibm-secure-tunnel-operator -o jsonpath='{.status.replicas}')
         NUM_DEPLOYMENT_OPERATORAVAILABLEREPLICAS=$(oc get deployment ibm-secure-tunnel-operator -o jsonpath='{.status.availableReplicas}')
         
-        NUM_STATEFULSET_REPLICAS=$(oc get statefulset sre-tunnel-controller -o jsonpath='{.status.replicas}')
-        NUM_STATEFULSET_READYREPLICAS=$(oc get statefulset sre-tunnel-controller -o jsonpath='{.status.readyReplicas}')
-        
         NUM_DEPLOYMENT_NETWORKAPIREPLICAS=$(oc get deployment sre-tunnel-tunnel-network-api -o jsonpath='{.status.replicas}')
         NUM_DEPLOYMENT_NETWORKAPIAVAILABLEREPLICAS=$(oc get deployment sre-tunnel-tunnel-network-api -o jsonpath='{.status.availableReplicas}')
         
@@ -693,7 +690,7 @@ then
         NUM_DEPLOYMENT_TUNNELUIAVAILABLEREPLICAS=$(oc get deployment sre-tunnel-tunnel-ui-mcmtunnelui -o jsonpath='{.status.availableReplicas}')
         
         DETAILS=$(oc get tunnels.sretooling.management.ibm.com -A -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.conditions[?(@.type==\"Deployed\")].status")
-        if [ "${INITIALIZED}" == "True" ] && [ "${DEPLOYED}" == "True" ] && [ "${NUM_DEPLOYMENT_OPERATORREPLICAS}" == "${NUM_DEPLOYMENT_OPERATORAVAILABLEREPLICAS}" ] && [ "${NUM_STATEFULSET_REPLICAS}" == "${NUM_STATEFULSET_READYREPLICAS}" ] && [ "${NUM_DEPLOYMENT_NETWORKAPIREPLICAS}" == "${NUM_DEPLOYMENT_NETWORKAPIAVAILABLEREPLICAS}" ] && [ "${NUM_DEPLOYMENT_TUNNELUIREPLICAS}" == "${NUM_DEPLOYMENT_TUNNELUIAVAILABLEREPLICAS}" ];
+        if [ "${INITIALIZED}" == "True" ] && [ "${DEPLOYED}" == "True" ] && [ "${NUM_DEPLOYMENT_OPERATORREPLICAS}" == "${NUM_DEPLOYMENT_OPERATORAVAILABLEREPLICAS}" ] && [ "${NUM_DEPLOYMENT_NETWORKAPIREPLICAS}" == "${NUM_DEPLOYMENT_NETWORKAPIAVAILABLEREPLICAS}" ] && [ "${NUM_DEPLOYMENT_TUNNELUIREPLICAS}" == "${NUM_DEPLOYMENT_TUNNELUIAVAILABLEREPLICAS}" ];
         then 
             SUCCESSFULLY_UPGRADED+="${newline}${DETAILS}"
             return 0;

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -732,16 +732,25 @@ then
     }
 
     # Check current instance version and component status checks for that version of CP4WAIOps
-    echo ""
-    echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} upgrade status:${normal}"
-
     if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
     then 
         component-versions-34
     elif [ "${VERSION_AIOPSORCHESTRATOR}" == "3.3" ]; 
     then
         component-versions-33
+    elif [ "${VERSION_AIOPSORCHESTRATOR}" == "0.1" ]
+    then
+        # for developer builds (v0.1), we will check against release-34 versions
+        component-versions-34
+        echo ""
+        echo "${red}${bold}NOTE: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be an internal dev version (v${VERSION_AIOPSORCHESTRATOR})."
+        echo "      The upgrade-status command checks the status of upgrades to v3.3 and v3.4 only." 
+        echo "      Therefore, the upgrade checks below will be against v3.4 component versions."
+        echo "      This may influence your results below if your dev build is not based on release-3.4.${normal}"
     fi
+
+    echo ""
+    echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} upgrade status:${normal}"
 
     aiopsEdgeBaseUpgradeStatus
     lifecycleUpgradeStatus

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -784,6 +784,13 @@ then
         echo "      The status-upgrade command checks the status of upgrades to v3.3 and v3.4 only." 
         echo "      Therefore, the upgrade checks below will be against v3.4 component versions."
         echo "      This may influence your results below if your dev build is not based on release-3.4.${normal}"
+    else
+        echo ""
+        echo "${red}${bold}ERROR: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be v${VERSION_AIOPSORCHESTRATOR}."
+        echo "       The status-upgrade command checks the status of upgrades to v3.3 and v3.4 only." 
+        echo "       The version you are using is not supported for use with the status-upgrade command. Exiting."
+        echo ""
+        exit 0
     fi
 
     echo ""

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -64,7 +64,7 @@ then
     STATUS_AB=$(oc get automationbase automationbase-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     STATUS_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     STATUS_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    STATUS_IR_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_IR_EP=$(oc get eventprocessor aiops-ir-lifecycle -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     STATUS_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     if [[ $STATUS_AUIC == "True" ]] && [[ $STATUS_AB == "True" ]] && [[ $STATUS_CARTRIDGE == "True" ]] && [[ $STATUS_CARTRIDGE_REQS == "True" ]] && [[ $STATUS_IR_EP == "True" ]] && [[ $STATUS_EP == "True" ]]; then
         printf '%s\n' "$green$INSTANCE$normal"
@@ -158,7 +158,7 @@ then
     STATUS_AB=$(oc get automationbase automationbase-sample -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     STATUS_CARTRIDGE=$(oc get cartridge cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     STATUS_CARTRIDGE_REQS=$(oc get cartridgerequirements cp4waiops-cartridge -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    STATUS_IR_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    STATUS_IR_EP=$(oc get eventprocessor aiops-ir-lifecycle -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     STATUS_EP=$(oc get eventprocessor cp4waiops-eventprocessor -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
     if [[ $STATUS_AUIC == "True" ]] && [[ $STATUS_AB == "True" ]] && [[ $STATUS_CARTRIDGE == "True" ]] && [[ $STATUS_CARTRIDGE_REQS == "True" ]] && [[ $STATUS_IR_EP == "True" ]] && [[ $STATUS_EP == "True" ]]; then
         printf '%s\n' "$green$INSTANCE$normal"

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -733,7 +733,7 @@ then
 
     # Check current instance version and component status checks for that version of CP4WAIOps
     echo ""
-    echo "${blue}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} upgrade status:${normal}"
+    echo "${blue}${bold}Cloud Pak for Watson AIOps AI Manager v${VERSION_AIOPSORCHESTRATOR} upgrade status:${normal}"
 
     if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
     then 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -141,6 +141,11 @@ KIND             NAMESPACE   NAME                   VERSION   STATUS   MESSAGE
 Postgreservice   cp4waiops   cp4waiops-postgres     1.0.0     True     Success to deploy postgres stolon cluster
 PostgresDB       cp4waiops   cp4waiops-postgresdb   1.0.0     True     Success to create postgres db
 ______________________________________________________________
+Secure Tunnel instances:
+
+KIND     NAMESPACE   NAME         STATUS
+Tunnel   katamari    sre-tunnel   True
+______________________________________________________________
 CSVs from cp4waiops namespace:
 
 NAME                                    DISPLAY                                            VERSION   REPLACES                                PHASE
@@ -295,6 +300,9 @@ VaultAccess   cp4waiops   ibm-vault-access   3.3.0     True     VaultAccess comp
 KIND             NAMESPACE   NAME                   VERSION   STATUS   MESSAGE
 Postgreservice   cp4waiops   cp4waiops-postgres     1.0.0     True     Success to deploy postgres stolon cluster
 PostgresDB       cp4waiops   cp4waiops-postgresdb   1.0.0     True     Success to create postgres db
+
+KIND     NAMESPACE   NAME         STATUS
+Tunnel   katamari    sre-tunnel   True
 
 KIND   NAMESPACE   NAME             VERSION   STATUS
 ASM    cp4waiops   aiops-topology   2.5.0     OK


### PR DESCRIPTION
- Added secure-tunnel checks to `status-all` and `status-upgrade` output
- Added color-coding to oc waiops status and oc waiops status-all outputs to visually indicate output status, similar to how oc waiops status-upgrade handles its output. This is done with green indicating success/completion/etc. and red indicating incomplete/failure/etc.
- Updated color-coding on `upgrade-status` to match scheme of `status` and `status-all`
- As a result of adding color to the output to indicate component state, this means that the status and status-all commands now actively check components' status, as opposed to simply passively printing the components' outputs as it did previously, making the commands more immediately useful or actionable for users. See comment below for example of how the color-coding looks.
- Updated `oc waiops status-upgrade` section of script to automatically check the versions of components automatically based on the install version of the CSV (3.3 or 3.4)
- Created notation in `oc waiops status-upgrade` in the event a dev build (v0.1) is encountered that it will be checked against v3.4 component versions
- Created notation in `oc waiops status-upgrade` in the event the install is not v3.4, v3.3, or v0.1 (i.e. could be 3.2/3.1/etc.) -- the script will exit as the tool does not support any other versions
- Updated script version to 0.0.7

In the comments below, I pasted some screenshots of what the color-coded outputs look like for `status` and `status-all`, in addition to new checks on `status-upgrade` depending on the version installed.