### PR TITLE
Add EDB Postgres status checks for 3.4 and 3.5 for `status-all`

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -343,7 +343,10 @@ then
         getCSVStatus "$INSTALLATION_NAMESPACE" "aimanager-operator"
         getCSVStatus "$INSTALLATION_NAMESPACE" "aiopsedge-operator"
         getCSVStatus "$INSTALLATION_NAMESPACE" "asm-operator"
-        getCSVStatus "$INSTALLATION_NAMESPACE" "couchdb-operator"
+        if [[ "${VERSION_AIOPSORCHESTRATOR}" == "3.3" ||  "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ]];
+        then 
+            getCSVStatus "$INSTALLATION_NAMESPACE" "couchdb-operator"
+        fi
         getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-ir-ai"
         getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-ir-core"
         getCSVStatus "$INSTALLATION_NAMESPACE" "ibm-aiops-ir-lifecycle"
@@ -389,7 +392,10 @@ then
         getSubscriptionStatus "aimanager-operator" "$INSTALLATION_NAMESPACE" 
         getSubscriptionStatus "aiopsedge-operator" "$INSTALLATION_NAMESPACE" 
         getSubscriptionStatus "asm-operator" "$INSTALLATION_NAMESPACE" 
-        getSubscriptionStatus "couchdb" "$INSTALLATION_NAMESPACE" 
+        if [[ "${VERSION_AIOPSORCHESTRATOR}" == "3.3" ||  "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ]];
+        then 
+            getSubscriptionStatus "couchdb" "$INSTALLATION_NAMESPACE" 
+        fi
         if [ "${CLUSTER_SCOPE_INSTALL}" == "false" ];
         then 
             getSubscriptionStatus "ibm-aiops-orchestrator" "$INSTALLATION_NAMESPACE" 
@@ -560,7 +566,7 @@ then
         component-versions-35() {
             MAJORVERSION_AIOPSUI="3.5"
             MAJORVERSION_AIMANAGER="2.6"
-            MAJORVERSION_IRCORE="3.6"
+            MAJORVERSION_IRCORE="3.5"
             MAJORVERSION_LIFECYCLESERVICE="3.5"
             MAJORVERSION_AIOPSANALYTICSORCHESTRATOR="3.5"
             MAJORVERSION_VAULTDEPLOY="3.5"
@@ -792,7 +798,7 @@ then
             component-versions-33
         elif [ "${VERSION_AIOPSORCHESTRATOR}" == "0.1" ]
         then
-            # for developer builds (v0.1), we will check against release-34 versions
+            # for developer builds (v0.1), we will check against release-3.5 versions
             component-versions-35
             echo ""
             echo "${red}${bold}NOTE: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be an internal dev version (v${VERSION_AIOPSORCHESTRATOR})."

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -318,8 +318,21 @@ then
         STATUS_VAULTACCESS=$(oc get vaultaccess ibm-vault-access -o jsonpath='{.status.conditions[].status}')
         printStatus "$STATUS_VAULTACCESS" "True" "$INSTANCE_VAULTACCESS"
 
-        echo "______________________________________________________________"
-        echo "Postgres (Postgreservices and PostgresDB) instances:" && echo ""  
+        
+        if [[ "${VERSION_AIOPSORCHESTRATOR}" != "3.3" ]];
+        then 
+            echo "______________________________________________________________"
+            echo "IBM Postgres (Postgreservices and PostgresDB) and EDB Postgres instances:" && echo "" 
+            
+            # EDB Postgres status-all
+            INSTANCE_EDBPOSTGRES=$(oc get clusters.postgresql.k8s.enterprisedb.io -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase")
+            STATUS_EDBPOSTGRES=$(oc get clusters.postgresql.k8s.enterprisedb.io -o jsonpath='{.items[].status.phase}')
+            printStatus "$STATUS_EDBPOSTGRES" "Cluster in healthy state" "$INSTANCE_EDBPOSTGRES" 
+        else
+            echo "______________________________________________________________"
+            echo "IBM Postgres (Postgreservices and PostgresDB) instances:" && echo "" 
+        fi 
+        
         # Postgreservices status-all
         INSTANCE_POSTGRESERVICES=$(oc get postgreservices cp4waiops-postgres -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,VERSION:spec.version,STATUS:status.conditions[?(@.type==\"Completed\")].status,MESSAGE:status.conditions[?(@.type==\"Completed\")].message")
         STATUS_POSTGRESERVICES=$(oc get postgreservices cp4waiops-postgres -o jsonpath='{.status.conditions[].status}')

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -557,6 +557,20 @@ then
             MAJORVERSION_FLINKEP="4.0"
         }
 
+        component-versions-35() {
+            MAJORVERSION_AIOPSUI="3.5"
+            MAJORVERSION_AIMANAGER="2.6"
+            MAJORVERSION_IRCORE="3.6"
+            MAJORVERSION_LIFECYCLESERVICE="3.5"
+            MAJORVERSION_AIOPSANALYTICSORCHESTRATOR="3.5"
+            MAJORVERSION_VAULTDEPLOY="3.5"
+            MAJORVERSION_VAULTACCESS="3.5"
+            MAJORVERSION_POSTGRESERVICE="1.0"
+            MAJORVERSION_POSTGRESDB="1.0"
+            MAJORVERSION_ASM="2.7"
+            MAJORVERSION_FLINKEP="4.0"
+        }
+
         aiopsEdgeBaseUpgradeStatus() {    
             UPGRADED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.conditions[?(@.type=="UpgradeReady")].status}')
             CONFIGURED=$(oc get aiopsedge aiopsedge -o jsonpath='{.status.phase}')
@@ -767,7 +781,10 @@ then
         }
 
         # Check current instance version and component status checks for that version of CP4WAIOps
-        if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
+        if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.5" ];
+        then 
+            component-versions-35
+        elif [ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ];
         then 
             component-versions-34
         elif [ "${VERSION_AIOPSORCHESTRATOR}" == "3.3" ]; 
@@ -776,16 +793,16 @@ then
         elif [ "${VERSION_AIOPSORCHESTRATOR}" == "0.1" ]
         then
             # for developer builds (v0.1), we will check against release-34 versions
-            component-versions-34
+            component-versions-35
             echo ""
             echo "${red}${bold}NOTE: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be an internal dev version (v${VERSION_AIOPSORCHESTRATOR})."
-            echo "      The status-upgrade command checks the status of upgrades to v3.3 and v3.4 only." 
-            echo "      Therefore, the upgrade checks below will be against v3.4 component versions."
-            echo "      This may influence your results below if your dev build is not based on release-3.4.${normal}"
+            echo "      The status-upgrade command checks the status of upgrades to v3.3, v3.4, and v3.5 only." 
+            echo "      Therefore, the upgrade checks below will be against v3.5 component versions."
+            echo "      This may influence your results below if your dev build is not based on release-3.5.${normal}"
         else
             echo ""
             echo "${red}${bold}ERROR: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be v${VERSION_AIOPSORCHESTRATOR}."
-            echo "       The status-upgrade command checks the status of upgrades to v3.3 and v3.4 only." 
+            echo "       The status-upgrade command checks the status of upgrades to v3.3, v3.4, and v3.5 only." 
             echo "       The version you are using is not supported for use with the status-upgrade command. Exiting."
             echo ""
             exit 0

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -322,7 +322,7 @@ then
         if [[ "${VERSION_AIOPSORCHESTRATOR}" != "3.3" ]];
         then 
             echo "______________________________________________________________"
-            echo "IBM Postgres (Postgreservices and PostgresDB) and EDB Postgres instances:" && echo "" 
+            echo "EDB Postgres and IBM Postgres (Postgreservices and PostgresDB) instances:" && echo "" 
             
             # EDB Postgres status-all
             INSTANCE_EDBPOSTGRES=$(oc get clusters.postgresql.k8s.enterprisedb.io -o custom-columns="KIND:kind,NAMESPACE:metadata.namespace,NAME:metadata.name,STATUS:status.phase")

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -25,7 +25,7 @@ CLUSTER_SCOPE_INSTALL=$(if [ $(oc get subscription -A  | grep ibm-aiops-orchestr
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.10"
+    echo "0.0.12"
     exit 0
 fi
 


### PR DESCRIPTION
* Added EDB Postgres status checks for 3.4 and 3.5 for `status-all`
* Updated script version to 0.0.12
* To be merged after #94 since the changes are based off the ones in that PR