### PR TITLE
Add basic user check to eliminate jumbo error output

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -48,7 +48,7 @@ fi
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    version="0.0.17"
+    version="0.0.18"
     exit 0
 fi
 

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -18,6 +18,17 @@ normal=$(tput sgr0) #reset color/bolding
 CLUSTER_ADMIN=$(oc auth can-i '*' '*' --all-namespaces)
 SECURE_TUNNEL_EXISTS=""
 SUMMARY_FAILURE=""
+USER_LEVEL=$(oc whoami) # to check if the user is running the tool at higher than a basic user role
+if [[ "$USER_LEVEL" == "basic" ]]
+then
+    echo ""
+    echo "${red}${bold}NOTE: ${normal}You do not have the appropriate permissions to run the CP4WAIOps status checker tool."
+    echo "      It appears you are logged in as a basic user. Please log in again" 
+    echo "      with credentials that have more permissions.${normal}"
+    echo ""
+    exit 0
+fi    
+
 if [[ "$CLUSTER_ADMIN" == "yes" ]];
 then 
     INSTALLATION_NAME=$(oc get installations.orchestrator.aiops.ibm.com -A --no-headers | while read a b c; do echo "$b"; done; 2>/dev/null)


### PR DESCRIPTION
* If a user is at a basic role level (`oc whoami` outputs `basic`), the status tool will not work. In this case, the tool would output a bunch of error messages. This PR resolves that
* Updated script version to `0.0.18`
