### PR TITLE
Update status checker for CP4WAIOps v3.7 based on release-3.7 branch

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -832,9 +832,8 @@ fi
 # optional argument handling
 if [[ "$1" == "status-upgrade" ]]
 then
-    # Script to check upgrade status of CP4WAIOps install for v3.3
-    # This script checks to see if your Cloud Pak for Watson AIOps
-    # instance is properly configured post-upgrade for v3.3. 
+    # This command checks the status of CP4WAIOps upgrades
+    # to v3.3, v3.4, v3.5, v3.6, and v3.7.
 
     FAILING_UPGRADE=""
     SUCCESSFULLY_UPGRADED=""
@@ -892,6 +891,18 @@ then
         MAJORVERSION_VAULTDEPLOY="3.6"
         MAJORVERSION_VAULTACCESS="3.6"
         MAJORVERSION_ASM="2.11"
+        MAJORVERSION_FLINKEP="4.0"
+    }
+
+    component-versions-37() {
+        MAJORVERSION_AIOPSUI="3.7"
+        MAJORVERSION_AIMANAGER="2.8"
+        MAJORVERSION_IRCORE="3.7"
+        MAJORVERSION_LIFECYCLESERVICE="3.7"
+        MAJORVERSION_AIOPSANALYTICSORCHESTRATOR="3.7"
+        MAJORVERSION_VAULTDEPLOY="3.7"
+        MAJORVERSION_VAULTACCESS="3.7"
+        MAJORVERSION_ASM="2.13"
         MAJORVERSION_FLINKEP="4.0"
     }
 
@@ -1118,7 +1129,10 @@ then
     }
 
     # Check current instance version and component status checks for that version of CP4WAIOps
-    if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.6" ];
+    if [ "${VERSION_AIOPSORCHESTRATOR}" == "3.7" ];
+    then 
+        component-versions-37
+    elif [ "${VERSION_AIOPSORCHESTRATOR}" == "3.6" ];
     then 
         component-versions-36
     elif [ "${VERSION_AIOPSORCHESTRATOR}" == "3.5" ];
@@ -1132,17 +1146,17 @@ then
         component-versions-33
     elif [ "${VERSION_AIOPSORCHESTRATOR}" == "0.1" ]
     then
-        # for developer builds (v0.1), we will check against release-3.6 versions
-        component-versions-36
+        # for developer builds (v0.1), we will check against release-3.7 versions
+        component-versions-37
         echo ""
         echo "${red}${bold}NOTE: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be an internal dev version (v${VERSION_AIOPSORCHESTRATOR})."
-        echo "      The status-upgrade command checks the status of upgrades to v3.3, v3.4, v3.5, and v3.6 only." 
-        echo "      Therefore, the upgrade checks below will be against v3.6 component versions."
-        echo "      This may influence your results below if your dev build is not based on release-3.6.${normal}"
+        echo "      The status-upgrade command checks the status of upgrades to v3.3, v3.4, v3.5, v3.6, and v3.7 only." 
+        echo "      Therefore, the upgrade checks below will be against v3.7 component versions."
+        echo "      This may influence your results below if your dev build is not based on release-3.7.${normal}"
     else
         echo ""
         echo "${red}${bold}ERROR: ${normal}Your Cloud Pak for Watson AIOps AI Manager install appears to be v${VERSION_AIOPSORCHESTRATOR}."
-        echo "       The status-upgrade command checks the status of upgrades to v3.3, v3.4, v3.5, and v3.6 only." 
+        echo "       The status-upgrade command checks the status of upgrades to v3.3, v3.4, v3.5, v3.6, and v3.7 only." 
         echo "       The version you are using is not supported for use with the status-upgrade command. Exiting."
         echo ""
         exit 0

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -48,7 +48,7 @@ fi
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    version="0.0.18"
+    version="0.0.19"
     exit 0
 fi
 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -318,7 +318,7 @@ Hint: for a more detailed printout of each operator's components' statuses, run 
 ## How to use
 
 ### Requirements
-- You must have an installation of Cloud Pak for Watson AIOps AI Manager v3.3, v3.4 or v3.5 on your cluster. 
+- You must have an installation of Cloud Pak for Watson AIOps AI Manager v3.3, v3.4, v3.5, v3.6, or v3.7 on your cluster. 
 
 **Note**: while this tool does not require you to be logged in as a cluster admin, `oc waiops status-all`'s output will be limited if you are not. If possible, it is recommended to be logged in as a cluster admin to receive a more complete view of your install status.
 


### PR DESCRIPTION
* Updated `oc waiops status-upgrade` to support CP4WAIOps v3.7 based on release-3.7 branch
* Updated script version to `0.0.19`
