### PR TITLE
(feat) - post cert-rotation rollout of ir-ai deployments

### DIFF
--- a/utils/3.7/issue-resolution-ai-post-cert-rotation-helper.sh
+++ b/utils/3.7/issue-resolution-ai-post-cert-rotation-helper.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+#
+# Copyright 2023 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Parameter Constants
+LOGGING_VERBOSITY=6;
+KUBECTL_CMD="oc";
+MAX_ATTEMPTS_FOR_SERVICE_ROLLOUT=100;
+MANAGED_BY_REFERENCE="aiops-analytics-operator"; CR_REFERENCE="aiopsanalyticsorchestrator";
+
+# Logging Constants
+CRITICAL_LOG_LEVEL=1; ERROR_LOG_LEVEL=2; WARN_LOG_LEVEL=3; OP_SUCC_LEVEL=4;
+INFO_LOG_LEVEL=5; DEBUG_LOG_LEVEL=6; STDOUT_RED='\033[0;31m'; STDOUT_GREEN='\033[0;32m';
+STDOUT_YELLOW='\033[0;33m'; STDOUT_PURPLE='\033[0;35m'; STDOUT_WHITE='\033[0;97m';
+STDOUT_RESET_CODE='\033[0m';
+
+# Global variables
+TRAPPED_STATUS_EXIT=0
+ROLLOUTS_SUCCEEDED=""
+ROLLOUTS_FAILED=""
+
+# Logging Functions
+function logcrit    () { LOG_LEVEL=$CRITICAL_LOG_LEVEL fmtlog "${STDOUT_RED}FATAL   - $@${STDOUT_RESET_CODE}" ;}
+function logerr     () { LOG_LEVEL=$ERROR_LOG_LEVEL    fmtlog "${STDOUT_RED}ERROR   - $@${STDOUT_RESET_CODE}" ;}
+function logdebug   () { LOG_LEVEL=$DEBUG_LOG_LEVEL    fmtlog "${STDOUT_PURPLE}DEBUG   - $@${STDOUT_RESET_CODE}" ;}
+function loginfo    () { LOG_LEVEL=$INFO_LOG_LEVEL     fmtlog "${STDOUT_WHITE}INFO    - $@${STDOUT_RESET_CODE}" ;}
+function logwarn    () { LOG_LEVEL=$WARN_LOG_LEVEL     fmtlog "${STDOUT_YELLOW}WARNING - $@${STDOUT_RESET_CODE}" ;}
+function logok      () { LOG_LEVEL=$OP_SUCC_LEVEL      fmtlog "${STDOUT_GREEN}SUCCESS - $@${STDOUT_RESET_CODE}" ;}
+function fmtlog     () {
+  if [ $LOGGING_VERBOSITY -ge $LOG_LEVEL ]; then
+    datestring=`date +"%Y-%m-%d %H:%M:%S"`
+    echo "$datestring - $@"
+  fi
+}
+
+# Test Functions
+# test_for_client is a function to check that the client executable exists on the path.
+# arguments: $1 client command
+function test_for_client() {
+  loginfo "Testing that user Openshift client exists in path"
+  which $1 &> /dev/null
+  if [ $? -eq 0 ]; then
+    logok "k8s Client exists in user path"
+  else
+    logcrit "The selected k8s client is not available"
+    exit 1
+  fi
+}
+
+# test_client_logged_in is a function to validate authorisation with an oc cluster.
+# arguments: $1 client command
+function test_client_logged_in() {
+  loginfo "Testing for authentication against Openshift"
+  $1 whoami &> /dev/null
+  if [ $? -eq 0 ]; then
+    logok "Authenticated against target oc cluster"
+  else
+    logcrit "You must be authenticated against the target \
+    cluster with a CLI session in order to use this script"
+    exit 1
+  fi
+}
+
+# test_can_find_orchestrators_in_namespace is a function to search for CR instances in the namespace provided.
+# arguments: $1 client command, $2 namespace
+function test_can_find_orchestrators_in_namespace() {
+  loginfo "Validating existance of orchestrators in the target namespace"
+  COUNT=$($1 get $CR_REFERENCE -n $2 | wc -l)
+  if [ "$COUNT" -eq "2" ]; then
+    logok "Found $CR_REFERENCE within target namespace $2"
+  else
+    logwarn "Could not find expected number of instances of the CR $CR_REFERENCE in namespace $2"
+    logcrit "Ensure there is exactly one instance of $CR_REFERENCE in namespace $2 to use this script"
+    exit 1
+  fi
+}
+
+# test_for_awk is a no arg dependency check function for awk
+function test_for_awk_wc() {
+  loginfo "Testing that user has awk installed in path"
+  which awk &> /dev/null
+  if [ $? -eq 0 ]; then
+    logok "awk exists in user path"
+  else
+    logcrit "awk is required to use this script"
+    exit 1
+  fi
+
+  loginfo "Testing that user has wc installed in path"
+  which wc &> /dev/null
+  if [ $? -eq 0 ]; then
+    logok "wc exists in user path"
+  else
+    logcrit "wc is required to use this script"
+    exit 1
+  fi
+}
+
+# rotate_deployments_for_dependency is a function that will perform rollout restarts for
+# a given array of deployments. arguments: @ - the array of deployments.
+function rotate_deployments_for_dependency() {
+  arr=("$@")
+  for i in "${arr[@]}";
+    do
+      loginfo "Executing rollout restarts for deployment $i"
+      $KUBECTL_CMD rollout restart $i
+      ATTEMPTS=0
+      
+      ROLLOUT_STATUS_CMD="$KUBECTL_CMD rollout status $i"
+      until $ROLLOUT_STATUS_CMD || [ $ATTEMPTS -eq $MAX_ATTEMPTS_FOR_SERVICE_ROLLOUT ]; do
+        $ROLLOUT_STATUS_CMD
+        ATTEMPTS=$((attempts + 1))
+        loginfo \
+        "failed attempt $ATTEMPTS executed of $MAX_ATTEMPTS_FOR_SERVICE_ROLLOUT,\
+          awaiting rollout status progress"
+        sleep 10
+      done
+
+      if [ $ATTEMPTS -ge $MAX_ATTEMPTS_FOR_SERVICE_ROLLOUT ]; then
+        logerr "deployment $i did not healthy replicas in a reasonable timeframe"
+        TRAPPED_STATUS_EXIT=1
+        ROLLOUTS_FAILED="$ROLLOUTS_FAILED \n o- $i"
+      else
+        logok "successfully updated $i"
+        ROLLOUTS_SUCCEEDED="$ROLLOUTS_SUCCEEDED \n o- $i"
+      fi
+    done
+}
+
+# Debug Information
+logdebug "executing with oc client cmd: $KUBECTL_CMD"
+USER_RUNNING_SCRIPT=$($KUBECTL_CMD whoami)
+logdebug "executing script as $USER_RUNNING_SCRIPT"
+CURRENT_NAMESPACE=$($KUBECTL_CMD config view --minify -o jsonpath='{..namespace}')
+logdebug "executing against target namespace $CURRENT_NAMESPACE"
+
+# Execute trivial tests to ensure all pre-reqs are satisfied
+test_for_client $KUBECTL_CMD
+test_client_logged_in $KUBECTL_CMD
+test_can_find_orchestrators_in_namespace $KUBECTL_CMD $CURRENT_NAMESPACE
+test_for_awk_wc
+
+# Begin Main Execution
+
+# Resolve the single orchestrator instance to determine annotations to select deployments via
+# Use awk over grep/sed for higher compatibility against target systems.
+loginfo "Attempting to resolve the target orchestrator instance"
+ORCHESTRATOR_CR_INSTANCE=$(
+  $KUBECTL_CMD get aiopsanalyticsorchestrator \
+    -n $CURRENT_NAMESPACE --no-headers=true -o custom-columns=":metadata.name"
+)
+
+if [ "$(echo $ORCHESTRATOR_CR_INSTANCE | wc -l)" -eq 1 ] && 
+   [ $(echo $ORCHESTRATOR_CR_INSTANCE | awk -F '//' '{ n = gsub(/ /, "", $1); print n }') -eq 0 ]; then
+  logok "Obtained the orchestrator instance without errors: $ORCHESTRATOR_CR_INSTANCE"
+else
+  logwarn "Orchestrators should have only a single instance per namespace within the Cloud pak for AIOps."
+  logwarn "Could not resolve the orchestrator instance. Either many exist, or none exist."
+  logcrit "Contact IBM Support providing the logs of this script within the case."
+  exit 1
+fi
+
+# Fetch the deployments based on the following labels: app.kubernetes.io/instance + app.kubernetes.io/managed-by
+loginfo "Resolving deployments Using orchestrator instance $ORCHESTRATOR_CR_INSTANCE"
+DEPLOYMENTS=()
+while read -r line; do
+   DEPLOYMENTS+=("$line")
+done <<< "$($KUBECTL_CMD get deploy \
+  --selector=app.kubernetes.io/managed-by=$MANAGED_BY_REFERENCE,app.kubernetes.io/instance=$ORCHESTRATOR_CR_INSTANCE \
+  --no-headers=true -o name)"
+
+DEPLOY_COUNT=$(echo "${DEPLOYMENTS[@]}" | awk '{print gsub("[ \t]",""); exit}')
+if [ $DEPLOY_COUNT -ge 0 ]; then
+  logok "Resolved deployments for orchestrator instance $ORCHESTRATOR_CR_INSTANCE without errors"
+else
+  logcrit "Could not find the expected number of deployments for the corresponding orchestrator instance"
+  exit 1
+fi
+
+# Rotate the deployments over, to cycle certificates and secrets
+logdebug "Detected deployments ${DEPLOYMENTS[@]}"
+loginfo "Starting service rotation for $ORCHESTRATOR_CR_INSTANCE"
+echo ${DEPLOYMENTS[1]}
+rotate_deployments_for_dependency "${DEPLOYMENTS[@]}"
+
+if [ $TRAPPED_STATUS_EXIT -eq 0 ]; then
+  loginfo "Rollouts succeeded for:"
+  echo $ROLLOUTS_SUCCEEDED
+else
+  loginfo "Rollouts failed for:"
+  echo $ROLLOUTS_FAILED
+fi
+
+logdebug "preparing to exit with status $TRAPPED_STATUS_EXIT"
+exit $TRAPPED_STATUS_EXIT

--- a/utils/3.7/issue-resolution-ai-post-cert-rotation-helper.sh
+++ b/utils/3.7/issue-resolution-ai-post-cert-rotation-helper.sh
@@ -141,8 +141,8 @@ function rotate_deployments_for_dependency() {
     done
 }
 
-# clear_crt_cache_for_dependency is a function that will attempt to clear files in the global `$CERT_DIR`
-# directory where the files match the pattern "$CERT_CACHE_PATTERN". This function assumes the STS members
+# clear_crt_cache_for_dependency is a function that will attempt to clear files in the global cert
+# directory where the files match the pattern *-cert-sum. This function assumes the STS members
 # are numerically named according to the count of replicas. eg. abc-0, abc-1 for a count of 2.
 function clear_crt_cache_for_dependency() {
   arr=("$@")


### PR DESCRIPTION
Facilitates the restart of all deployments for a single instance of the kind aiopsanalyticsorchestrator, for proposed usage immediately after certificate rotation occurs.

Official documentation will follow; however for the purposes of this change request, I've provided the key information for reviewers.

## What the script does:
* Finds and executes rollout of all deployments that belong to the CR instance.
* If the version of the CR instance detected should include spark as an STS, it attempts to clear up the certificate cache prior to executing a rollout as a precautionary step to help ensure any persistence relating to certificates is cleared prior. Note, this clean up is only required since spark became an STS, so if it's not present it ought to be handled by the previous step operating on deployments.

## Dependencies:
The script itself will validate its dependencies, which include awk, wc, an oc client installation accessible via the cmd `oc`. The script itself depends on bash.

The script requires the user executing to have particular permissions that are not validated, inclduing access to get/rollout on statefulsets/deployments, access to get/delete pods, as well as exec access to pods in the namespace.

Simplifying this, it is best to advise that an administrator user of the cp4aiops project, likely `aiops` executes this script on a unix or osx based operating system.

## Usage steps:
1. Log in to the target cluster, eg. `oc login xyz`
2. Use the target project/namespace `oc project aiops`
3. invoke the script using bash shell `sh issue-resolution-ai-post-cert-rotation-helper.sh` or simply `./issue-resolution-ai-post-cert-rotation-helper.sh` if a user will opt to set the +x flag using `chmod +x`.
4. Await results of all rollouts.

## The example output to stdout of execution is as follows:

```
bash-3.2$ sh utils/3.7/issue-resolution-ai-post-cert-rotation-helper.sh
2023-04-25 11:52:23 - DEBUG   - executing with oc client cmd: oc
2023-04-25 11:52:24 - DEBUG   - executing script as kube:admin
2023-04-25 11:52:24 - DEBUG   - executing against target namespace aiops
2023-04-25 11:52:24 - INFO    - Testing that user Openshift client exists in path
2023-04-25 11:52:24 - SUCCESS - k8s Client exists in user path
2023-04-25 11:52:24 - INFO    - Testing for authentication against Openshift
2023-04-25 11:52:24 - SUCCESS - Authenticated against target oc cluster
2023-04-25 11:52:24 - INFO    - Validating existance of orchestrators in the target namespace
2023-04-25 11:52:25 - SUCCESS - Found aiopsanalyticsorchestrator within target namespace aiops
2023-04-25 11:52:25 - INFO    - Testing that user has awk installed in path
2023-04-25 11:52:25 - SUCCESS - awk exists in user path
2023-04-25 11:52:25 - INFO    - Testing that user has wc installed in path
2023-04-25 11:52:25 - SUCCESS - wc exists in user path
2023-04-25 11:52:25 - INFO    - Attempting to resolve the target orchestrator instance
2023-04-25 11:52:26 - SUCCESS - Obtained the orchestrator instance without errors: aiops
2023-04-25 11:52:26 - INFO    - Resolving deployments Using orchestrator instance aiops
2023-04-25 11:52:27 - SUCCESS - Resolved deployments for orchestrator instance aiops without errors
2023-04-25 11:52:27 - DEBUG   - Detected deployments deployment.apps/aiops-ir-analytics-classifier deployment.apps/aiops-ir-analytics-metric-action deployment.apps/aiops-ir-analytics-metric-api deployment.apps/aiops-ir-analytics-metric-spark deployment.apps/aiops-ir-analytics-probablecause deployment.apps/aiops-ir-analytics-spark-master deployment.apps/aiops-ir-analytics-spark-pipeline-composer
2023-04-25 11:52:27 - INFO    - Starting service rotation for aiops
2023-04-25 11:52:27 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-classifier
deployment.apps/aiops-ir-analytics-classifier restarted
Waiting for deployment "aiops-ir-analytics-classifier" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "aiops-ir-analytics-classifier" rollout to finish: 1 old replicas are pending termination...
deployment "aiops-ir-analytics-classifier" successfully rolled out
2023-04-25 11:53:52 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-classifier
2023-04-25 11:53:52 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-metric-action
deployment.apps/aiops-ir-analytics-metric-action restarted
Waiting for deployment "aiops-ir-analytics-metric-action" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "aiops-ir-analytics-metric-action" rollout to finish: 1 old replicas are pending termination...
deployment "aiops-ir-analytics-metric-action" successfully rolled out
2023-04-25 11:54:07 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-metric-action
2023-04-25 11:54:07 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-metric-api
deployment.apps/aiops-ir-analytics-metric-api restarted
Waiting for deployment "aiops-ir-analytics-metric-api" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "aiops-ir-analytics-metric-api" rollout to finish: 1 old replicas are pending termination...
deployment "aiops-ir-analytics-metric-api" successfully rolled out
2023-04-25 11:56:12 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-metric-api
2023-04-25 11:56:12 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-metric-spark
deployment.apps/aiops-ir-analytics-metric-spark restarted
Waiting for deployment "aiops-ir-analytics-metric-spark" rollout to finish: 0 of 1 updated replicas are available...
deployment "aiops-ir-analytics-metric-spark" successfully rolled out
2023-04-25 11:57:17 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-metric-spark
2023-04-25 11:57:17 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-probablecause
Warning: spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key: beta.kubernetes.io/arch is deprecated since v1.14; use "kubernetes.io/arch" instead
deployment.apps/aiops-ir-analytics-probablecause restarted
Waiting for deployment "aiops-ir-analytics-probablecause" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "aiops-ir-analytics-probablecause" rollout to finish: 1 old replicas are pending termination...
deployment "aiops-ir-analytics-probablecause" successfully rolled out
2023-04-25 11:58:35 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-probablecause
2023-04-25 11:58:36 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-spark-master
deployment.apps/aiops-ir-analytics-spark-master restarted
Waiting for deployment "aiops-ir-analytics-spark-master" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "aiops-ir-analytics-spark-master" rollout to finish: 1 old replicas are pending termination...
deployment "aiops-ir-analytics-spark-master" successfully rolled out
2023-04-25 12:00:01 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-spark-master
2023-04-25 12:00:01 - INFO    - Executing rollout restarts for deployment deployment.apps/aiops-ir-analytics-spark-pipeline-composer
Warning: spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key: beta.kubernetes.io/arch is deprecated since v1.14; use "kubernetes.io/arch" instead
deployment.apps/aiops-ir-analytics-spark-pipeline-composer restarted
Waiting for deployment "aiops-ir-analytics-spark-pipeline-composer" rollout to finish: 0 of 1 updated replicas are available...
deployment "aiops-ir-analytics-spark-pipeline-composer" successfully rolled out
2023-04-25 12:02:02 - SUCCESS - successfully updated deployment.apps/aiops-ir-analytics-spark-pipeline-composer
2023-04-25 12:02:09 - INFO    - detected version 3.7.0/3.7.1, attempting to rollout Spark STS
2023-04-25 12:02:10 - DEBUG   - Detected statefulsets statefulset.apps/aiops-ir-analytics-spark-worker
2023-04-25 12:02:10 - INFO    - Fetching replicas count for statefulset statefulset.apps/aiops-ir-analytics-spark-worker
Found 2 replicas for statefulset statefulset.apps/aiops-ir-analytics-spark-worker
attempting to clear cert cache for replica statefulset.apps/aiops-ir-analytics-spark-worker-
Defaulted container "spark-worker" out of: spark-worker, spark-worker-wait-for-master (init)
attempting to clear cert cache for replica statefulset.apps/aiops-ir-analytics-spark-worker-
Defaulted container "spark-worker" out of: spark-worker, spark-worker-wait-for-master (init)
2023-04-25 12:02:15 - INFO    - Executing rollout restarts for deployment statefulset.apps/aiops-ir-analytics-spark-worker
statefulset.apps/aiops-ir-analytics-spark-worker restarted
Waiting for partitioned roll out to finish: 0 out of 2 new pods have been updated...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
Waiting for partitioned roll out to finish: 1 out of 2 new pods have been updated...
Waiting for 1 pods to be ready...
Waiting for 1 pods to be ready...
partitioned roll out complete: 2 new pods have been updated...
2023-04-25 12:08:43 - SUCCESS - successfully updated statefulset.apps/aiops-ir-analytics-spark-worker
2023-04-25 12:08:43 - INFO    - Rollouts succeeded for:

 o- deployment.apps/aiops-ir-analytics-classifier 
 o- deployment.apps/aiops-ir-analytics-metric-action 
 o- deployment.apps/aiops-ir-analytics-metric-api 
 o- deployment.apps/aiops-ir-analytics-metric-spark 
 o- deployment.apps/aiops-ir-analytics-probablecause 
 o- deployment.apps/aiops-ir-analytics-spark-master 
 o- deployment.apps/aiops-ir-analytics-spark-pipeline-composer 
 o- statefulset.apps/aiops-ir-analytics-spark-worker
2023-04-25 12:08:43 - DEBUG   - preparing to exit with status 0
```

## Notes

The user can safely ignore the warnings regarding `beta.kubernetes.io/arch` if they are encountered on OC 4.10/4.12