### PR TITLE
Fix `oc waiops version` to properly output version number

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -48,7 +48,7 @@ fi
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    version="0.0.19"
+    echo "0.0.19"
     exit 0
 fi
 


### PR DESCRIPTION
* Fixed `oc waiops version` to properly output version number with an `echo`