### PR TITLE
3.7.1 Install Tool Updates

### DIFF
--- a/prereq-checker/3.7/README.md
+++ b/prereq-checker/3.7/README.md
@@ -1,0 +1,37 @@
+# IBM Cloud Pak for Watson AIOps AI Manager prerequisite checker tool
+
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
+
+**Pre-Install Checker::**
+
+- **OpenShift version check** : Checks whether the Red Hat OpenShift Container Platform cluster version is a fully supported Extended Update Support (EUS) version and compatible for installing IBM Cloud Pak for Watson AIOps AI Manager. OpenShift Container Platform 4.10.46+ is currently under full support and compatible. **New deployments of AI Manager 3.7.1 or higher are supported on Red Hat OpenShift Container Platform 4.12. Upgraded deployments of AI Manager are not supported on Red Hat OpenShift Container Platform 4.12. This is because the version of Redis, a component used by AI Manager, varies between new deployments and upgraded deployments of AI Manager.**
+
+- **Storage check**: Checks whether a storage class that uses a supported storage provider (Portworx, Red Hat Openshift Data Foundation (ODF), or IBMC-file-gold-gid) is available on the cluster. For more information, see the IBM Documentation [Storage considerations](https://ibm.biz/storage_consideration_371).
+
+- **Network policy check**: Checks whether the network policy is configured for the AI Manager routes, which allow external traffic to reach the routes. For more information about how the network policy is configured, see the IBM Documentation [Configure network policies](https://ibm.biz/aiops_netpolicy_371).
+
+- **Small or large profile install check**: Checks whether the cluster has enough resources (vCPU, Memory, and Nodes) for installing a small or large profile of IBM Cloud Pak for Watson AIOps AI Manager. For more information, see the IBM Documentation [Hardware requirements](https://ibm.biz/aiops_hardware_371).
+
+- **Entitlement Secret check**: Checks whether a secret called ibm-entitlement-key or a global pull secret called pull-secret (global pull secret found in openshift-config namespace) have been created. For more information, see the IBM Documentation [Entitlement Keys](https://ibm.biz/entitlement_keys_371)
+
+## Getting started
+
+Clone the following GitHub repository:
+
+```
+  git clone https://github.com/IBM/cp4waiops-samples
+  cd cp4waiops-samples/prereq-checker/3.7
+```
+
+## Running the prerequisite & upgrade checker tool script
+
+**IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for Watson AIOps AI Manager.
+```
+oc project <namespace_name>
+ex: oc project cp4waiops
+```
+
+To run the prerequisite checker tool, run the following command:
+```
+  ./prereq.sh
+```

--- a/prereq-checker/3.7/README.md
+++ b/prereq-checker/3.7/README.md
@@ -6,7 +6,13 @@ The prerequisite checker tool can be used to validate whether a Red Hat OpenShif
 
 - **OpenShift version check** : Checks whether the Red Hat OpenShift Container Platform cluster version is a fully supported Extended Update Support (EUS) version and compatible for installing IBM Cloud Pak for Watson AIOps AI Manager. OpenShift Container Platform 4.10.46+ is currently under full support and compatible. **New deployments of AI Manager 3.7.1 or higher are supported on Red Hat OpenShift Container Platform 4.12. Upgraded deployments of AI Manager are not supported on Red Hat OpenShift Container Platform 4.12. This is because the version of Redis, a component used by AI Manager, varies between new deployments and upgraded deployments of AI Manager.**
 
-- **Storage check**: Checks whether a storage class that uses a supported storage provider (Portworx, Red Hat Openshift Data Foundation (ODF), or IBMC-file-gold-gid) is available on the cluster. For more information, see the IBM Documentation [Storage considerations](https://ibm.biz/storage_consideration_371).
+- **Storage check**: Checks whether a storage class that uses a supported storage provider (Portworx, Red Hat Openshift Data Foundation (ODF), Storage Fusion or IBMC-file-gold-gid) is available on the cluster. For more information, see the IBM Documentation [Storage considerations](https://ibm.biz/storage_consideration_371).
+
+**NOTE: If you plan to use Storage Fusion with AIOPS, please keep in mind the following OCP version dependencies**
+| Storage Fusion Version     | OCP Versions supported |
+| -------------------------- | ---------------------- |
+| Storage Fusion v2.4        | OCP v4.8 and v4.10     |
+| Storage Fusion v2.5        | OCP v4.10 and v4.12    |
 
 - **Network policy check**: Checks whether the network policy is configured for the AI Manager routes, which allow external traffic to reach the routes. For more information about how the network policy is configured, see the IBM Documentation [Configure network policies](https://ibm.biz/aiops_netpolicy_371).
 

--- a/uninstall/README.md
+++ b/uninstall/README.md
@@ -1,0 +1,37 @@
+# Uninstall Cloud Pak for Watson AIOps
+
+The scripts provided here can be used to uninstall Cloud Pak for Watson AIOps and delete resources created by it.  This includes optionally uninstalling the IBM Automation Foundation (IAF).  IAF is the common layer shared by multiple Cloud Paks.
+
+## Prereqs
+- You need to have OC CLI installed
+- You have logged into your cluster using `oc login`
+
+## Getting started
+
+Clone this repo.
+```
+  git clone https://github.ibm.com/katamari/katamari-util.git 
+  cd uninstall/
+```
+
+## Preparing for uninstall
+
+There are resources created by Cloud Pak for Watson AIOps that you should review before deleting.  These include PVCs, secrets, CRDs, and config maps.  You might want to save some of these or consider not deleting them if you plan to reinstall.  You can check the `./3.x/uninstall-cp4waiops-resource-groups.sh` file for a list of resources that the script will delete.  You can update this list with resources you don't want to delete.
+
+There are also resources that are shared by multiple Cloud Paks that Cloud Pak for Watson AIOps might install if it was not already created by a different Cloud Pak.  You want to make sure those are not deleted if you are using other Cloud Paks on your cluster.  
+
+Once you have carefully reviewed and decided on what to delete, you can move forward to the next step and update the `./3.x/uninstall-cp4waiops-props.sh` file with your preferences.
+
+## Configure what to uninstall
+The `./3.x/uninstall-cp4waiops-props.sh` file is used to tell the uninstall script what to uninstall and cleanup.  Update the properties in this file with your preference.  An explanation for each property is provided in the file.
+
+## Running the uninstall script
+Once you have updated the `./3.x/uninstall-cp4waiops-props.sh` file, you are ready to run the script!  
+
+To run the uninstall, you can run
+```
+  cd 3.x
+  ./uninstall-cp4waiops.sh
+```
+
+You can choose to skip confirmation messages by passing in `-s`.


### PR DESCRIPTION
## Overview
* Adding readme in uninstall folder vs adding it each release folder
* Pre-Req Checker
  * Update OCP version check. Fresh deployments of 3.7.1 can use OCP v4.12, whereas upgrades cannot
    * README also edited to show this
  * Suppresses a warning that occurs on a job pod for entitlement secret check