### PR TITLE
Update kubectl-waiops to address false negatives: CP4AIOps 3.7.x + IA

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -151,37 +151,69 @@ getZenServiceStatus() {
 
 getAUICStatus() {
     # AutomationUIConfig status
-    INSTANCE_AUIC=$(oc get automationuiconfig -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
     if [[ "$CLUSTER_ADMIN" == "yes" ]];
     then
-        NAME_AUIC=$(oc get automationuiconfig -A --no-headers | while read a b c; do echo "$b"; done; 2>/dev/null)
-    else    
-        NAME_AUIC=$(oc get automationuiconfig --no-headers | while read a b c; do echo "$a"; done; 2>/dev/null)
-    fi
-    STATUS_AUIC=$(oc get automationuiconfig $NAME_AUIC -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ "$1" == "status-summary" ]];
-    then
-        printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC" "status-summary"
+        AUIC_INSTANCES=$(oc get automationuiconfig -A --no-headers | while read a b c; do echo "$a $b"; done; 2>/dev/null)
+        AUICS=()
+        while IFS= read -r line; do
+            AUICS+=("$line")
+        done <<< "$AUIC_INSTANCES"
+
+        for string in "${AUICS[@]}"; do
+            read -r NAMESPACE AUIC <<< "$string"
+            INSTANCE_AUIC=$(oc get automationuiconfig -n $NAMESPACE -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+            STATUS_AUIC=$(oc get automationuiconfig $AUIC -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+            if [[ "$1" == "status-summary" ]];
+            then
+                printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC" "status-summary"
+            else
+                printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC"
+            fi
+        done
     else
-        printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC"
+        INSTANCE_AUIC=$(oc get automationuiconfig -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+        NAME_AUIC=$(oc get automationuiconfig --no-headers | while read a b c; do echo "$a"; done; 2>/dev/null)
+        STATUS_AUIC=$(oc get automationuiconfig $NAME_AUIC -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+        if [[ "$1" == "status-summary" ]];
+        then
+            printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC" "status-summary"
+        else
+            printStatus "$STATUS_AUIC" "True" "$INSTANCE_AUIC"
+        fi
     fi
 }
 
 getABStatus() {
-    # AutomationBase status
-    INSTANCE_AB=$(oc get automationbase -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+    # AutomationBase status    
     if [[ "$CLUSTER_ADMIN" == "yes" ]];
     then
-        NAME_AB=$(oc get automationbase -A --no-headers | while read a b c; do echo "$b"; done; 2>/dev/null)
-    else    
-        NAME_AB=$(oc get automationbase --no-headers | while read a b c; do echo "$a"; done; 2>/dev/null)
-    fi
-    STATUS_AB=$(oc get automationbase $NAME_AB -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
-    if [[ "$1" == "status-summary" ]];
-    then
-        printStatus "$STATUS_AB" "True" "$INSTANCE_AB" "status-summary"
+        AB_INSTANCES=$(oc get automationbase -A --no-headers | while read a b c; do echo "$a $b"; done; 2>/dev/null)
+        ABS=()
+        while IFS= read -r line; do
+            ABS+=("$line")
+        done <<< "$AB_INSTANCES"
+
+        for string in "${ABS[@]}"; do
+            read -r NAMESPACE AB <<< "$string"
+            INSTANCE_AB=$(oc get automationbase -n $NAMESPACE -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')
+            STATUS_AB=$(oc get automationbase $AB -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+            if [[ "$1" == "status-summary" ]];
+            then
+                printStatus "$STATUS_AB" "True" "$INSTANCE_AB" "status-summary"
+            else
+                printStatus "$STATUS_AB" "True" "$INSTANCE_AB"
+            fi
+        done       
     else
-        printStatus "$STATUS_AB" "True" "$INSTANCE_AB"
+        INSTANCE_AB=$(oc get automationbase -o custom-columns='KIND:.kind,NAMESPACE:.metadata.namespace,NAME:.metadata.name,VERSION:status.versions.reconciled,STATUS:.status.conditions[?(@.type=="Ready")].status,MESSAGE:.status.conditions[?(@.type=="Ready")].message')    
+        NAME_AB=$(oc get automationbase --no-headers | while read a b c; do echo "$a"; done; 2>/dev/null)
+        STATUS_AB=$(oc get automationbase $NAME_AB -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+        if [[ "$1" == "status-summary" ]];
+        then
+            printStatus "$STATUS_AB" "True" "$INSTANCE_AB" "status-summary"
+        else
+            printStatus "$STATUS_AB" "True" "$INSTANCE_AB"
+        fi
     fi
 }
 


### PR DESCRIPTION
The current implementation of `kubectl-waiops` throws _**false negatives**_ regarding the instances for `AutomationUIConfig` and `AutomationBase` when Infrastructure Automation is a separate install to CP4AIOps. As reference, see output below from `kubectl-waiops` when ran against an OCP cluster where CP4AIOps v3.7.2 is installed in the `cp4waiops` namespace and Infrastructure Automation is installed in the `ia` namespace.

This PR addresses this problem by adding logic to look up the instances for `AutomationUIConfig` and `AutomationBase` in the right namespaces  as opposed to assuming all of the instances are found in the same namespace... which again throws false negatives as captured in the output below.

```
______________________________________________________________
ZenService instances:

KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
ZenService   iaf-zen-cpdservice   cp4waiops   4.8.5     Completed   100%       The Current Operation Is Completed

______________________________________________________________
AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:

Error from server (NotFound): [automationuiconfigs.core.automation.ibm.com](http://automationuiconfigs.core.automation.ibm.com/) "ia-automationuiconfig" not found
KIND                 NAMESPACE   NAME         VERSION   STATUS   MESSAGE
AutomationUIConfig   cp4waiops   iaf-system   1.3.12    True     AutomationUIConfig successfully registered

Error from server (NotFound): [automationbases.base.automation.ibm.com](http://automationbases.base.automation.ibm.com/) "ia-automationbase" not found
KIND             NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
AutomationBase   cp4waiops   automationbase-sample   2.0.12    True     AutomationBase instance successfully created

KIND        NAMESPACE   NAME                  VERSION   STATUS   MESSAGE
Cartridge   cp4waiops   cp4waiops-cartridge   1.3.12    True     Cartridge successfully registered

KIND                    NAMESPACE   NAME                  VERSION   STATUS   MESSAGE
CartridgeRequirements   cp4waiops   cp4waiops-cartridge   1.3.12    True     CartridgeRequirements successfully registered

KIND             NAMESPACE   NAME                 VERSION   STATUS   MESSAGE
EventProcessor   cp4waiops   aiops-ir-lifecycle   3.0.0     True     Event Processor is ready

KIND             NAMESPACE   NAME                       VERSION   STATUS   MESSAGE
EventProcessor   cp4waiops   cp4waiops-eventprocessor   4.0.13    True     Event Processor is ready

______________________________________________________________
IRCore and AIOpsAnalyticsOrchestrator instances:

KIND                  NAMESPACE   NAME    VERSION   STATUS   MESSAGE
IssueResolutionCore   cp4waiops   aiops   3.7.2     Ready    All Services Ready
```

The following output is generated when using the updated code for `kubectl-waiops` as captured in this PR:

```
$ oc waiops status
Already on project "cp4waiops" on server "https://api.natters.cp.fyre.ibm.com:6443".

Cloud Pak for Watson AIOps AI Manager v3.7 installation status:
______________________________________________________________
Installation instances:

NAME                  PHASE     LICENSE    STORAGECLASS   STORAGECLASSLARGEBLOCK   AGE
ibm-cp-watson-aiops   Running   Accepted   rook-cephfs    rook-ceph-block          160d

______________________________________________________________
ZenService instances:

KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
ZenService   iaf-zen-cpdservice   cp4waiops   4.8.5     Completed   100%       The Current Operation Is Completed

______________________________________________________________
AutomationUIConfig, AutomationBase, Cartridge, CartridgeRequirements, and EventProcessor instances:

KIND                 NAMESPACE   NAME         VERSION   STATUS   MESSAGE
AutomationUIConfig   cp4waiops   iaf-system   1.3.12    True     AutomationUIConfig successfully registered

KIND                 NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
AutomationUIConfig   ia          ia-automationuiconfig   1.3.12    True     AutomationUIConfig successfully registered

KIND             NAMESPACE   NAME                    VERSION   STATUS   MESSAGE
AutomationBase   cp4waiops   automationbase-sample   2.0.12    True     AutomationBase instance successfully created

KIND             NAMESPACE   NAME                VERSION   STATUS   MESSAGE
AutomationBase   ia          ia-automationbase   2.0.12    True     AutomationBase instance successfully created

KIND        NAMESPACE   NAME                  VERSION   STATUS   MESSAGE
Cartridge   cp4waiops   cp4waiops-cartridge   1.3.12    True     Cartridge successfully registered

KIND                    NAMESPACE   NAME                  VERSION   STATUS   MESSAGE
CartridgeRequirements   cp4waiops   cp4waiops-cartridge   1.3.12    True     CartridgeRequirements successfully registered

KIND             NAMESPACE   NAME                 VERSION   STATUS   MESSAGE
EventProcessor   cp4waiops   aiops-ir-lifecycle   3.0.0     True     Event Processor is ready

KIND             NAMESPACE   NAME                       VERSION   STATUS   MESSAGE
EventProcessor   cp4waiops   cp4waiops-eventprocessor   4.0.13    True     Event Processor is ready

______________________________________________________________
IRCore and AIOpsAnalyticsOrchestrator instances:

KIND                  NAMESPACE   NAME    VERSION   STATUS   MESSAGE
IssueResolutionCore   cp4waiops   aiops   3.7.2     Ready    All Services Ready

KIND                         NAMESPACE   NAME    VERSION   STATUS   MESSAGE
AIOpsAnalyticsOrchestrator   cp4waiops   aiops   3.7.2     Ready    All Services Ready

______________________________________________________________
LifecycleService instances:

KIND               NAMESPACE   NAME    VERSION   STATUS   MESSAGE
LifecycleService   cp4waiops   aiops   3.7.2     <none>   All Services Ready

______________________________________________________________
BaseUI instances:

KIND     NAMESPACE   NAME              VERSION   STATUS   MESSAGE
BaseUI   cp4waiops   baseui-instance   3.7.2     True     Ready

______________________________________________________________
AIManager, ASM, AIOpsEdge, and AIOpsUI instances:

KIND        NAMESPACE   NAME        VERSION   STATUS      MESSAGE
AIManager   cp4waiops   aimanager   2.8.2     Completed   AI Manager is ready

KIND   NAMESPACE   NAME             VERSION   STATUS
ASM    cp4waiops   aiops-topology   2.13.2    OK

KIND        NAMESPACE   NAME        STATUS       MESSAGE
AIOpsEdge   cp4waiops   aiopsedge   Configured   all critical components are reporting healthy

KIND      NAMESPACE   NAME               VERSION   STATUS   MESSAGE
AIOpsUI   cp4waiops   aiopsui-instance   3.7.2     True     Ready

______________________________________________________________

Hint: for a more detailed printout of component statuses, run `oc waiops status-all`.
```