### PR TITLE
Fix uninstall README to link to cp4waiops-samples repo, not katamari-util

### DIFF
--- a/uninstall/README.md
+++ b/uninstall/README.md
@@ -12,7 +12,7 @@ Note: For uninstall scripts v3.x, the script includes optionally uninstalling th
 
 Clone this repo.
 ```
-  git clone https://github.ibm.com/katamari/katamari-util.git 
+  git clone https://github.com/IBM/cp4waiops-samples.git
   cd uninstall/
 ```
 


### PR DESCRIPTION
* Fixed uninstall README to link to cp4waiops-samples repo for the clone command, rather than the katamari-util internal repo