### PR TITLE
Add v4.1-onwards optional-use message to the top of status tool readme

### DIFF
--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -1,4 +1,4 @@
-#### ***NOTE**: <u>from CP4WAIOps v4.1.0 onwards, the use of this status-checking tool is now considered **optional**.</u> Please primarily refer to the installation status messages provided directly in the `ibm-aiops-orchestrator` CR of your cluster's installation.*
+#### ***NOTE**: from CP4WAIOps v4.1.0 onwards, the use of this status-checking tool is now considered **optional**. Please primarily refer to the installation status messages provided directly in the `ibm-aiops-orchestrator` CR of your cluster's installation.*
 
 # kubectl-waiops
 

--- a/kubectl-plugin/waiops-status.md
+++ b/kubectl-plugin/waiops-status.md
@@ -1,3 +1,5 @@
+#### ***NOTE**: <u>from CP4WAIOps v4.1.0 onwards, the use of this status-checking tool is now considered **optional**.</u> Please primarily refer to the installation status messages provided directly in the `ibm-aiops-orchestrator` CR of your cluster's installation.*
+
 # kubectl-waiops
 
 A kubectl plugin for CP4WAIOps


### PR DESCRIPTION
* Added optional-use message to the top of the status tool's readme to indicate optional usage from v4.1.0 onwards. Instead, users can primarily reference the in-orchestrator status checks in the `ibm-aiops-orchestrator` CR instead