### PR TITLE
Script to resolve connector "red status" issue post v3 to v4 upgrade

### DIFF
--- a/upgrade/v3-to-v4/connectors/README.md
+++ b/upgrade/v3-to-v4/connectors/README.md
@@ -1,0 +1,31 @@
+# Resolve "red status" issue in AIOps Connectors after upgrading from AIOPs 3.x to 4.x
+
+If one or more connectors are showing a red status icon in the Connections UI after upgrading from AIOps v3.x to v4.x, it could be caused by a problem when the operator failed to update a resource in the cluster. The issue is seen in metrics connector because they use a persistent storage and starting from AIOps 4.1, the access mode has been updated to `ReadWriteOnce` from `ReadWriteMany`.
+
+## Running the script on all connections
+
+1. Login to the Openshift cluster with administrator privilage.
+2. (Optional) Check for any `GitApp` resources that may be stuck in `Retrying` phase.
+    ```sh
+    oc get gitapp
+    ```
+3. Run the script with `--all` to attempt the fix on all problematic connections.
+   ```sh
+   recreate-connector-storage.sh --namespace <AIOps namespace> --all
+   ```
+4. All connector `GitApp` resource status should now be `Configured`.
+
+## Running the script on a single connection
+
+To run the script on a single connection:
+
+1. Get the connection name and note the resource name
+   ```sh
+   oc get connectorconfiguration --namespace <AIOps namespace>
+   ```
+2. Run the script with `--all` to attempt the fix on all problematic connections.
+   ```sh
+   recreate-connector-storage.sh --namespace <AIOps namespace> --connection <connectionconfiguration name>
+   ```
+3. All connector `GitApp` resource status should now be `Configured`.
+

--- a/upgrade/v3-to-v4/connectors/README.md
+++ b/upgrade/v3-to-v4/connectors/README.md
@@ -1,4 +1,4 @@
-# Resolve "red status" issue in AIOps Connectors after upgrading from AIOPs 3.x to 4.x
+# Resolve "red status" issue in AIOps connections after upgrading from AIOPs 3.x to 4.x
 
 If one or more connectors are showing a red status icon in the Connections UI after upgrading from AIOps v3.x to v4.x, it could be caused by a problem when the operator failed to update a resource in the cluster. The issue is seen in metrics connector because they use a persistent storage and starting from AIOps 4.1, the access mode has been updated to `ReadWriteOnce` from `ReadWriteMany`.
 

--- a/upgrade/v3-to-v4/connectors/README.md
+++ b/upgrade/v3-to-v4/connectors/README.md
@@ -1,6 +1,18 @@
 # Resolve "red status" issue in AIOps connections after upgrading from AIOPs 3.x to 4.x
 
-If one or more connectors are showing a red status icon in the Connections UI after upgrading from AIOps v3.x to v4.x, it could be caused by a problem when the operator failed to update a resource in the cluster. The issue is seen in metrics connector because they use a persistent storage and starting from AIOps 4.1, the access mode has been updated to `ReadWriteOnce` from `ReadWriteMany`.
+If one or more connectors are showing a red status icon in the Connections UI after upgrading from AIOps v3.x to v4.x, it could be caused by a problem when the operator failed to update a resource in the cluster. The issue could occur in metrics connectors or Netcool/OMNIbus connector because they use a persistent storage and starting from AIOps 4.1, the access mode has been updated to `ReadWriteOnce` from `ReadWriteMany`.
+
+An example event that indicates the deployment update failed is shown below:
+
+```sh
+$ oc describe gitapp c18fce82-2a7b-45f2-8d36-d34417576fe7 
+
+<output omitted...>
+Events:
+  Type     Reason           Age                     From    Message
+  ----     ------           ----                    ----    -------
+  Warning  ReconcileError   145m (x15005 over 29h)  GitApp  Deployables: failed to apply connector deployment yaml to cluster: StatefulSet.apps "ibm-dyna-conn-9c02b6f2-6e37-4646-bee3-bafef95d9c2d" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
+```
 
 ## Running the script on all connections
 

--- a/upgrade/v3-to-v4/connectors/recreate-connector-storage.sh
+++ b/upgrade/v3-to-v4/connectors/recreate-connector-storage.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+#
+# Copyright 2023 IBM Inc. All rights reserved
+# SPDX-License-Identifier: Apache2.0
+#
 set -euo pipefail
-# set -o xtrace
+# set -o xtrace # Uncomment for debugging.
 
 # ---------- Defaults -------------------
 : ${AWK:=awk}

--- a/upgrade/v3.7-to-v4/connectors/recreate-connector-storage.sh
+++ b/upgrade/v3.7-to-v4/connectors/recreate-connector-storage.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# set -o xtrace
+
+# ---------- Defaults -------------------
+: ${AWK:=awk}
+: ${ALL_CONNECTORS:=false}
+: ${CONNECTION_NAME:=""}
+
+# ---------- Command functions ----------
+function usage() {
+	local script="${0##*/}"
+
+	while read -r ; do echo "${REPLY}" ; done <<-EOF
+	Usage: ${script} [OPTION]...
+	Recreate Connector Storage
+
+	Options:
+	Mandatory arguments to long options are mandatory for short options too.
+      -h, --help                    Display this help and exit
+      -n, --namespace               The namespace where AIOps is installed. (Mandatory)
+      -c, --connection              The ConnectorConfiguration name to update storage. This option is ignored if "-a/--all" option is set.
+      -a, --all                     Recreate for all existing connectors
+EOF
+}
+
+
+function toggleDataFlow() {
+    local conn=${1}
+    local toggle=${2}
+    
+    if [[ $toggle == "off" ]]; then
+        value="false"
+        msg "Disable connector data flow"
+    else
+        value="true"
+        msg "Enable connector data flow"
+    fi
+    if [[ $connconfigType == "netcool-connector" ]]; then
+        if [[ $(oc get connectorconfiguration $connconfig -o jsonpath='{.spec.config.collectAlerts}') != "$value" ]]; then
+            patch="'{\"spec\":{\"config\":{\"collectAlerts\": $value}}}'"
+            CMD="oc patch connectorconfiguration $connconfig --type='merge' -p $patch"
+            printAndExecute "$CMD"
+            doSleep="true"
+        fi
+    else
+        if [[ $(oc get connectorconfiguration $connconfig -o jsonpath='{.spec.config.enableDataFlow}') != "$value" ]]; then
+            patch="'{\"spec\":{\"config\":{\"enableDataFlow\": $value}}}'"
+            CMD="oc patch connectorconfiguration $connconfig --type='merge' -p $patch"
+            printAndExecute "$CMD"
+            doSleep="true"
+        fi
+    fi
+    if [[ ${doSleep:-} == "true" ]]; then
+        info "Giving time for connector to pause data flow" 
+        sleep 30
+    fi
+}
+
+
+function getDataFromStorage(){
+    title "Checking connector storage for data extraction."
+    info "Events for GitApp: $gitappName"
+    CMD="oc get event --namespace $NS --field-selector involvedObject.name=$gitappName,type==Warning"
+    printAndExecute "$CMD"
+
+    backupDataRequired=false
+    if [[ $gitappStatus != "Configured" ]]; then
+        # Check for specific error when an upgrade changes an immutable field.
+        msg "Checking for error updating connector resources ..."
+        backupDataRequired=true
+        if [[ $($CMD -o json | jq '.items[] | select(.message | test("Forbidden: updates to statefulset spec for fields other than.*")) | .message' | wc -l) -gt 0 ]]; then
+            msg "\"Unable to update Statefulset error\" event found."
+        else
+            warning "WARNING: Did not find any event that indicate Statefulset update error occurred because it may have been updated. Proceeding anyway ..."
+        fi
+    fi
+
+    if [[ $backupDataRequired != "true" ]]; then
+        msg "No need to extract data from PVC"
+        return;
+    fi
+
+    connectorPvc=$(oc get pvc --namespace $NS --no-headers -l instance=connector-$connconfigUid -o jsonpath='{.items[*].metadata.name}')
+    if [[ -z $connectorPvc ]]; then
+        echo "Connector does not use storage. Skip data extraction."
+        backupDataRequired=false
+        return
+    fi
+
+    msg "Connector PVC: $connectorPvc"
+    pvcAccessMode=$(oc get pvc --namespace $NS $connectorPvc -o jsonpath='{.spec.accessModes[]}' | grep ReadWriteOnce | wc -l)
+    if [[ $pvcAccessMode -ne 0 ]]; then
+        echo "Connector storage access mode is already using ReadWriteOnce (RWO). Skip data extraction."
+        backupDataRequired=false
+        return
+    fi
+
+    connectorPod=$(oc get pod --namespace $NS --no-headers -l instance=connector-$connconfigUid -o jsonpath='{.items[*].metadata.name}')
+
+    # Get the data file path
+    connectorWorkload=$(oc get statefulset --namespace $NS --no-headers -l connectors.aiops.ibm.com/git-app-name=$gitappName -o jsonpath='{.items[*].metadata.name}')
+    volumeName=$(oc get statefulset --namespace $NS $connectorWorkload -o jsonpath='{.spec.volumeClaimTemplates[].metadata.name}')
+    volumeMountPath=$(oc get statefulset --namespace $NS $connectorWorkload -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="'$volumeName'")].mountPath }')
+    dataFilePath=$volumeMountPath
+
+    if [[ -z $dataFilePath ]]; then
+        backupDataRequired=false
+        return
+    fi      
+
+    # Check if there's files to backup
+    fileCount=$(oc exec --namespace $NS $connectorPod -- /bin/bash -c "find $volumeMountPath -type f | wc -l")
+    if [ $fileCount -eq 0 ]; then
+        echo "No files found in PVC to extract."
+        backupDataRequired=false
+        return
+    fi
+
+    targetDir=/tmp/$connconfig/$dataFilePath
+    rm -rf $targetDir
+    mkdir -p $targetDir
+
+    # Disable dataflow
+    toggleDataFlow "$connconfig" "off"
+
+    CMD="oc cp --retries=3 --namespace $NS $connectorPod:$dataFilePath $targetDir/"
+    info "Extracting data $dataFilePath file from pod: $connectorPod"
+    printAndExecute "$CMD"
+
+    msg "Files extracted"
+    ls -R $targetDir
+    
+    connectorWorkload=$(oc get statefulset --namespace $NS --no-headers -l connectors.aiops.ibm.com/git-app-name=$gitappName -o jsonpath='{.items[*].metadata.name}')
+    info "Scaling down connector workload: $connectorWorkload and delete PVC"
+    CMD="oc scale --namespace $NS statefulset/$connectorWorkload --replicas 0 && oc delete pvc/$connectorPvc --namespace $NS --timeout=300s"
+    printAndExecute "$CMD"
+
+    info "Watching rollout ..."
+    CMD="oc rollout status statefulset/$connectorWorkload --namespace $NS --timeout=300s"
+    printAndExecute "$CMD"
+
+    local cycle=1
+    local maxRetry=$((12 * 5)) # 5 minutes
+    while [[ ! $(oc get pod $connectorPod --namespace $NS --no-headers) ]]; do
+        msg "Checking pod $connectorPod"
+        sleep 5
+        cycle=$(( $cycle + 1 ))
+        if [ $cycle  -gt $maxRetry ]; then
+            podStatus=$(oc get pod $connectorPod --namespace $NS --no-headers -o custom-columns=":status.phase")
+            error "Pod $connectorPod status is still not yet deleted, current status: $podStatus. Pod may be stuck and could not be deleted. Exit."
+            exit 1
+        fi
+    done
+
+    info "Deleting Statefulset: $connectorWorkload"
+    CMD="oc delete statefulset/$connectorWorkload --namespace $NS --timeout=60s"
+    printAndExecute "$CMD"
+}
+
+function insertConnectorData(){
+
+    if [[ $backupDataRequired != "true" ]]; then
+        return;
+    fi
+
+    if [[ -z ${targetDir:-} ]]; then
+        msg "No data to insert in persistent storage."
+        return;
+    fi
+
+    title "Preparing to insert backup data."
+    info "Checking for workload and PVC creation"
+
+    local cycle=1
+    local maxRetry=$((6 * 5)) # 5 minutes
+    while [[ ! $(oc get statefulset --namespace $NS --no-headers -l connectors.aiops.ibm.com/git-app-name=$gitappName) ]]; do
+        sleep 10
+        cycle=$(( $cycle + 1 ))
+        if [ $cycle -gt $maxRetry ]; then
+            exit 1
+        fi
+    done
+    connectorWorkload=$(oc get statefulset --namespace $NS --no-headers -l connectors.aiops.ibm.com/git-app-name=$gitappName -o jsonpath='{.items[*].metadata.name}')
+    connectorPvc=$(oc get pvc --namespace $NS --no-headers -l instance=connector-$connconfigUid -o jsonpath='{.items[*].metadata.name}')
+    volumeName=$(oc get statefulset --namespace $NS $connectorWorkload -o jsonpath='{.spec.volumeClaimTemplates[].metadata.name}')
+    volumeMountPath=$(oc get statefulset --namespace $NS $connectorWorkload -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="'$volumeName'")].mountPath }')
+
+    info "Found statefulset: $connectorWorkload"
+    info "Found PVC: $connectorPvc"
+    info "Making sure rollout is complete ..."
+    CMD="oc rollout status --namespace $NS statefulset/$connectorWorkload --timeout=300s"
+    printAndExecute "$CMD"
+
+    local cycle=1
+    local maxRetry=$((6 * 5)) # 5 minutes
+    while [[ ! $(oc get pvc --namespace $NS --no-headers -l instance=connector-$connconfigUid) ]]; do
+        sleep 10
+        cycle=$(( $cycle + 1 ))
+        if [ $cycle -gt $maxRetry ]; then
+            error "Timeout waiting for PVC to be created. Exit."
+            exit 1
+        fi
+    done
+
+    connectorPod=$(oc get pod --no-headers --namespace $NS -l instance=connector-$connconfigUid -o jsonpath='{.items[*].metadata.name}')
+    
+    local cycle=1
+    local maxRetry=$((6 * 5)) # 5 minutes
+    while [[ $(oc get pod $connectorPod --namespace $NS --no-headers -o custom-columns=":status.phase") != "Running" ]]; do
+        sleep 10
+        cycle=$(( $cycle + 1 ))
+        if [ $cycle -gt $maxRetry ]; then
+            error "Timeout waiting for pod $connectorPod to run. Exit."
+            exit 1
+        fi
+    done
+    
+    CMD="oc cp --retries=3 $targetDir $connectorPod:$volumeMountPath/.."
+    info "Inserting data $targetDir directory into pod: $connectorPod"
+    printAndExecute "$CMD"
+
+    CMD="oc exec --namespace $NS $connectorPod -- /bin/bash -c \"find $volumeMountPath -type f\""
+    printAndExecute "$CMD"
+    
+    info "Scaling down connector workload $connectorWorkload to restart pod."
+    CMD="oc scale statefulset/$connectorWorkload --namespace $NS --replicas 0"
+    printAndExecute "$CMD"
+
+    info "Watching rollout ..."
+    CMD="oc rollout status --namespace $NS statefulset/$connectorWorkload"
+    printAndExecute "$CMD"
+
+    CMD="oc scale statefulset/$connectorWorkload --namespace $NS --replicas 1"
+    printAndExecute "$CMD"
+
+    info "Watching rollout ..."
+    CMD="oc rollout status --namespace $NS statefulset/$connectorWorkload"
+    printAndExecute "$CMD"
+
+    ## Enable dataflow
+    toggleDataFlow "$connconfig" "on"
+}
+
+function getConnectorInfo(){
+    local connection=$1
+    msg "Getting ConnectorConfiguration: $connection"
+    CMD="oc get ConnectorConfiguration $connection --namespace $NS"
+    printAndExecute "$CMD"
+
+    connconfig=$(oc get connectorconfiguration --no-headers --namespace $NS --field-selector metadata.name=$connection -o jsonpath='{.items[*].metadata.name}')
+    connconfigUid=$(oc get connectorconfiguration $connconfig --namespace $NS -o jsonpath='{.metadata.uid}')
+    connconfigType=$(oc get connectorconfiguration $connconfig --namespace $NS -o jsonpath='{.spec.type}')
+    gitappName=$(oc get gitapp --namespace $NS -l connectors.aiops.ibm.com/connection-id==$connconfigUid --no-headers -o jsonpath='{.items[*].metadata.name}')
+    gitappStatus=$(oc get gitapp $gitappName --namespace $NS -o jsonpath='{.status.phase}')
+
+    msg "ConnectorConfiguration id: $connconfigUid"
+    msg "GitApp name: $gitappName"
+}
+
+function recreateStorage(){
+
+    if [[ $ALL_CONNECTORS != "true" ]]; then
+        title "Processing ConnectorConfiguration: $CONNECTION_NAME"
+        getConnectorInfo "$CONNECTION_NAME"
+        getDataFromStorage "$CONNECTION_NAME"
+        insertConnectorData "$CONNECTION_NAME"
+        success "Done processing ConnectorConfiguration: $CONNECTION_NAME"
+    else
+        count=1
+        totalConnectors=$(oc get connectorconfiguration --no-headers -o jsonpath='{.items[*].metadata.name}' | wc -w | tr -d ' ')
+        for connection in $(oc get connectorconfiguration --no-headers --namespace $NS -o jsonpath="{.items[*].metadata.name}"); do
+            title "Processing ConnectorConfiguration ($count/$totalConnectors connectors): $connection"
+            getConnectorInfo "$connection"
+            getDataFromStorage "$connection"
+            insertConnectorData "$connection"
+            success "Done processing ConnectorConfiguration ($count/$totalConnectors connectors) : $connection"
+            count=$((count + 1))
+        done
+    fi
+
+}
+
+function printAndExecute() {
+    local cmd=$1
+    msg "$cmd"
+    eval "$cmd"
+}
+
+function msg() {
+    printf '%b\n' "$1\n"
+}
+
+function success() {
+    msg "\33[32m[✔] ${1}\33[0m"
+}
+
+function error() {
+    msg "\33[31m[✘] ${1}\33[0m"
+}
+
+function title() {
+    msg "\33[34m# ${1}\33[0m"
+}
+
+function info() {
+    msg "[INFO] ${1}"
+}
+
+function warning() {
+    msg "\33[33m[✗] ${1}\33[0m"
+}
+
+
+function main(){
+
+    while [ "$#" -gt "0" ]
+    do
+        case "$1" in
+        "-h"|"--help")
+            usage
+            exit 0
+            ;;
+        "-n"|"--namespace")
+            NS=$2
+            shift
+            ;;
+        "-c"|"--connection")
+            CONNECTION_NAME=$2
+            shift
+            ;;
+        "-a"|"--all")
+            ALL_CONNECTORS="true"
+            ;;
+        *)
+            warning "invalid option -- \`$1\`"
+            usage
+            exit 1
+            ;;
+        esac
+        shift
+    done
+
+    title "Starting ..."
+    if [[ -z $CONNECTION_NAME ]] && [[ $ALL_CONNECTORS == "false" ]]; then
+        error "Script expects a ConnectorConfiguration resource name. Please specify a ConnectorConfiguration resource name."
+        usage
+        return
+    fi
+
+    if [[ -z ${NS:-} ]]; then
+        error "Namespace is not specified. Please specify the AIOps namespace."
+        usage
+        return
+    fi
+
+    recreateStorage "$@"
+
+    success "Complete ..."
+}
+
+main "$@"


### PR DESCRIPTION
Provide a script that user can run to resolve "red status" issue on connections post upgrading from AIOps v3.x to v4.x caused by a change in the storage class access mode in connectors that uses persistent volumes such as Netcool/OMNIbus connector or metric connectors.