### PR TITLE
Fix cluster-scoped `status-all` issue related to CS subscription check

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -50,7 +50,7 @@ fi
 # optional argument handling
 if [[ "$1" == "version" ]]
 then
-    echo "0.0.21"
+    echo "0.0.22"
     exit 0
 fi
 
@@ -750,8 +750,8 @@ then
         fi
         getSubscriptionStatusGrep "ibm-automation-elastic" "$INSTALLATION_NAMESPACE" 
         getSubscriptionStatusGrep "ibm-automation-flink" "$INSTALLATION_NAMESPACE" 
+        getSubscriptionStatusGrep "ibm-common-service-operator" "$INSTALLATION_NAMESPACE" 
     fi
-    getSubscriptionStatusGrep "ibm-common-service-operator" "$INSTALLATION_NAMESPACE" 
     getSubscriptionStatus "ibm-management-kong" "$INSTALLATION_NAMESPACE" 
     if [[ "${VERSION_AIOPSORCHESTRATOR}" == "3.3" ]] || [[ "${VERSION_AIOPSORCHESTRATOR}" == "3.4" ]] || [[ "${VERSION_AIOPSORCHESTRATOR}" == "3.5" ]];
     then


### PR DESCRIPTION
* Fixed cluster-scoped `status-all` issue related to incorrectly looking for CS sub in the wrong namespace
* Updated script version to `0.0.22`