### PR TITLE
Add certificate readiness check

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -454,6 +454,19 @@ getODLMPodStatus() {
     fi
 }
 
+getAllCertStatus() {
+    AIOPS_CERTS=()                                                                                                                                                                                                             
+    while IFS= read -r line; do
+        AIOPS_CERTS+=( "$line" )
+    done < <( oc get certificate -n $INSTALLATION_NAMESPACE -o=custom-columns='NAME:.metadata.name' --no-headers=true )
+    echo "Certificate Name               Renewal Time"
+    for c in "${AIOPS_CERTS[@]}"; do
+        certStatus=$(oc get cert $c --no-headers=true | awk '{print $2}')
+        renewalTime=$(oc get cert $c -o jsonpath='{.status.renewalTime}')
+        printStatus "$certStatus" "True" "$c    $renewalTime"
+    done
+}
+
 getOrchestratorPodStatus() {
     INSTANCE=$(oc get pod -A | grep ibm-aiops-orchestrator-controller-manager)
     if [[ "$CLUSTER_ADMIN" == "yes" ]];
@@ -1347,6 +1360,10 @@ then
         printf "${gray}[INFO] Skipping the following component (Hint: log in with CLUSTER_ADMIN credentials to view):${normal}${newline}"
         clusterAdminSkipMessage "operand-deployment-lifecycle-manager"
     fi
+
+    echo "______________________________________________________________"
+    echo "AIOps certificate status:" && echo ""
+    getAllCertStatus
 
     echo "______________________________________________________________"
     echo "Orchestrator pod current status:" && echo ""   

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -461,9 +461,9 @@ getAllCertStatus() {
     done < <( oc get certificate -n $INSTALLATION_NAMESPACE -o=custom-columns='NAME:.metadata.name' --no-headers=true )
     echo "Certificate Name               Renewal Time"
     for c in "${AIOPS_CERTS[@]}"; do
-        certStatus=$(oc get cert $c --no-headers=true | awk '{print $2}')
-        renewalTime=$(oc get cert $c -o jsonpath='{.status.renewalTime}')
-        printStatus "$certStatus" "True" "$c    $renewalTime"
+        CERT_STATUS=$(oc get cert $c --no-headers=true | awk '{print $2}')
+        CERT_RENEWAL=$(oc get cert $c -o custom-columns="NAME:metadata.name,RENEWAL:status.renewalTime,READY:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")
+        printStatus "$CERT_STATUS" "True" "$CERT_RENEWAL"
     done
 }
 
@@ -1350,6 +1350,10 @@ then
     fi
 
     echo "______________________________________________________________"
+    echo "AIOps certificate status:" && echo ""
+    getAllCertStatus
+
+    echo "______________________________________________________________"
     echo "ODLM pod current status:" && echo ""
     if [[ "$CLUSTER_ADMIN" == "yes" ]];
     then
@@ -1358,10 +1362,6 @@ then
         printf "${gray}[INFO] Skipping the following component (Hint: log in with CLUSTER_ADMIN credentials to view):${normal}${newline}"
         clusterAdminSkipMessage "operand-deployment-lifecycle-manager"
     fi
-
-    echo "______________________________________________________________"
-    echo "AIOps certificate status:" && echo ""
-    getAllCertStatus
 
     echo "______________________________________________________________"
     echo "Orchestrator pod current status:" && echo ""   

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -459,7 +459,6 @@ getAllCertStatus() {
     while IFS= read -r line; do
         AIOPS_CERTS+=( "$line" )
     done < <( oc get certificate -n $INSTALLATION_NAMESPACE -o=custom-columns='NAME:.metadata.name' --no-headers=true )
-    echo "Certificate Name               Renewal Time"
     for c in "${AIOPS_CERTS[@]}"; do
         CERT_STATUS=$(oc get cert $c --no-headers=true | awk '{print $2}')
         CERT_RENEWAL=$(oc get cert $c -o custom-columns="NAME:metadata.name,RENEWAL:status.renewalTime,READY:status.conditions[?(@.type==\"Ready\")].status,MESSAGE:status.conditions[?(@.type==\"Ready\")].message")

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1245,8 +1245,6 @@ then
                     getSubscriptionStatusGrep "ibm-automation-flink" "openshift-operators" 
                 fi
                 getSubscriptionStatusGrep "aiops-ibm-common-services" "openshift-operators"
-            # else
-            #     TODO: update this to check for cert manager certificate expiry
             fi
         else
             printf "${gray}[INFO] Skipping the following components (Hint: log in with CLUSTER_ADMIN credentials to view):${normal}${newline}"


### PR DESCRIPTION
This PR introduces a step to the status checker kubectl plugin to validate the readiness of AIOps certificates. The check uses the status of the certificate Ready condition, which verifies that the certificate is up-to-date and not expired. The check also prints the renewal time if available.