### PR TITLE
Fixing Problem with Subscription Lookup

### DIFF
--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1260,7 +1260,10 @@ then
                     getSubscriptionStatusGrep "ibm-automation-elastic" "openshift-operators" 
                     getSubscriptionStatusGrep "ibm-automation-flink" "openshift-operators" 
                 fi
-                getSubscriptionStatusGrep "aiops-ibm-common-services" "openshift-operators"
+
+                if [[ "${VERSION_AIOPSORCHESTRATOR}" != "4.4" || "${VERSION_AIOPSORCHESTRATOR}" != "0.1" ]]; then
+                    getSubscriptionStatusGrep "aiops-ibm-common-services" "openshift-operators"
+                fi
             fi
         else
             printf "${gray}[INFO] Skipping the following components (Hint: log in with CLUSTER_ADMIN credentials to view):${normal}${newline}"

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1261,7 +1261,7 @@ then
                     getSubscriptionStatusGrep "ibm-automation-flink" "openshift-operators" 
                 fi
 
-                if [[ "${VERSION_AIOPSORCHESTRATOR}" != "4.4" || "${VERSION_AIOPSORCHESTRATOR}" != "0.1" ]]; then
+                if [[ "${VERSION_AIOPSORCHESTRATOR}" != "4.4" || "${VERSION_AIOPSORCHESTRATOR}" != "0.1" || "${VERSION_AIOPSORCHESTRATOR}" != "4.5" ]]; then
                     getSubscriptionStatusGrep "aiops-ibm-common-services" "openshift-operators"
                 fi
             fi

--- a/kubectl-plugin/kubectl-waiops
+++ b/kubectl-plugin/kubectl-waiops
@@ -1241,6 +1241,7 @@ then
             getSubscriptionStatus "ibm-im-mongodb-operator" "$INSTALLATION_NAMESPACE"
             getSubscriptionStatus "ibm-platformui-operator" "$INSTALLATION_NAMESPACE"
             getSubscriptionStatus "operand-deployment-lifecycle-manager-app" "$INSTALLATION_NAMESPACE"
+            getSubscriptionStatusGrep "aiops-ibm-common-services" "$INSTALLATION_NAMESPACE"
 
             if [ "${CLUSTER_SCOPE_INSTALL}" == "true" ];
             then 
@@ -1259,10 +1260,6 @@ then
                 then
                     getSubscriptionStatusGrep "ibm-automation-elastic" "openshift-operators" 
                     getSubscriptionStatusGrep "ibm-automation-flink" "openshift-operators" 
-                fi
-
-                if [[ "${VERSION_AIOPSORCHESTRATOR}" != "4.4" || "${VERSION_AIOPSORCHESTRATOR}" != "0.1" || "${VERSION_AIOPSORCHESTRATOR}" != "4.5" ]]; then
-                    getSubscriptionStatusGrep "aiops-ibm-common-services" "openshift-operators"
                 fi
             fi
         else


### PR DESCRIPTION
## Overview
Fixing an issue wherein the tool looks up the CS sub in the openshift-operators namespace. From AIOPs 4.4, there was a change in which CS would only exist per cloud-pak. This meant that the subscription for it would exist in our install namespace.

### Sample output
```console
$ oc waiops status-all

Cloud Pak for AIOps v4.5 installation status:
______________________________________________________________
Installation instances:

NAME           PHASE     LICENSE    STORAGECLASS                STORAGECLASSLARGEBLOCK        AGE
ibm-cp-aiops   Running   Accepted   ocs-storagecluster-cephfs   ocs-storagecluster-ceph-rbd   66m

______________________________________________________________
ZenService instances:

KIND         NAME                 NAMESPACE   VERSION   STATUS      PROGRESS   MESSAGE
ZenService   iaf-zen-cpdservice   cp4aiops    5.1.1     Completed   100%       The Current Operation Is Completed

______________________________________________________________
Kafka and Elasticsearch instances:

KIND    NAMESPACE   NAME         STATUS
Kafka   cp4aiops    iaf-system   True

KIND            NAMESPACE   NAME         STATUS
Elasticsearch   cp4aiops    iaf-system   True

______________________________________________________________
IRCore and AIOpsAnalyticsOrchestrator instances:

KIND                  NAMESPACE   NAME    VERSION   STATUS   MESSAGE
IssueResolutionCore   cp4aiops    aiops   4.5.0     Ready    All Services Ready

KIND                         NAMESPACE   NAME    VERSION   STATUS   MESSAGE
AIOpsAnalyticsOrchestrator   cp4aiops    aiops   4.5.0     Ready    All Services Ready

______________________________________________________________
LifecycleService instances:

KIND               NAMESPACE   NAME    VERSION   STATUS   MESSAGE
LifecycleService   cp4aiops    aiops   4.5.0     Ready    All Services Ready

______________________________________________________________
BaseUI instances:

KIND     NAMESPACE   NAME              VERSION   STATUS   MESSAGE
BaseUI   cp4aiops    baseui-instance   4.5.0     True     Ready

______________________________________________________________
AIManager, ASM, AIOpsEdge, and AIOpsUI instances:

KIND        NAMESPACE   NAME        VERSION   STATUS      MESSAGE
AIManager   cp4aiops    aimanager   4.5.0     Completed   AI Manager is ready

KIND   NAMESPACE   NAME             VERSION   STATUS
ASM    cp4aiops    aiops-topology   2.22.0    OK

KIND        NAMESPACE   NAME        STATUS       MESSAGE
AIOpsEdge   cp4aiops    aiopsedge   Configured   all critical components are reporting healthy

KIND      NAMESPACE   NAME               VERSION   STATUS   MESSAGE
AIOpsUI   cp4aiops    aiopsui-instance   4.5.0     True     Ready

______________________________________________________________
Kong instances:

KIND   NAMESPACE   NAME      STATUS   MESSAGE
Kong   cp4aiops    gateway   True     <none>

______________________________________________________________
Postgres instances:

KIND      NAMESPACE   NAME                        STATUS
Cluster   cp4aiops    ibm-cp-aiops-edb-postgres   Cluster in healthy state
Cluster   cp4aiops    zen-metastore-edb           Cluster in healthy state

______________________________________________________________
CSVs from cp4aiops namespace:

NAME                                         DISPLAY                VERSION                  REPLACES   PHASE
aimanager-operator.v4.5.0-rc1-202403120045   IBM AIOps AI Manager   4.5.0-rc1-202403120045              Succeeded

NAME                                         DISPLAY          VERSION                  REPLACES   PHASE
aiopsedge-operator.v4.5.0-rc1-202403120045   IBM AIOps Edge   4.5.0-rc1-202403120045              Succeeded

NAME                                   DISPLAY                             VERSION                  REPLACES   PHASE
asm-operator.v4.5.0-rc1-202403120045   IBM Netcool Agile Service Manager   4.5.0-rc1-202403120045              Succeeded

NAME                                      DISPLAY                                            VERSION                  REPLACES   PHASE
ibm-aiops-ir-ai.v4.5.0-rc1-202403120045   IBM Watson AIOps Issue Resolution AI & Analytics   4.5.0-rc1-202403120045              Succeeded

NAME                                        DISPLAY                                  VERSION                  REPLACES   PHASE
ibm-aiops-ir-core.v4.5.0-rc1-202403120045   IBM Watson AIOps Issue Resolution Core   4.5.0-rc1-202403120045              Succeeded

NAME                                             DISPLAY                                    VERSION                  REPLACES   PHASE
ibm-aiops-ir-lifecycle.v4.5.0-rc1-202403120045   IBM Cloud Pak for Watson AIOps Lifecycle   4.5.0-rc1-202403120045              Succeeded

NAME                                             DISPLAY                   VERSION                  REPLACES   PHASE
ibm-aiops-orchestrator.v4.5.0-rc1-202403120045   IBM Cloud Pak for AIOps   4.5.0-rc1-202403120045              Succeeded

NAME                             DISPLAY       VERSION   REPLACES   PHASE
ibm-automation-elastic.v1.3.16   IBM Elastic   1.3.16               Succeeded

NAME                           DISPLAY                           VERSION   REPLACES   PHASE
ibm-automation-flink.v1.3.16   IBM Automation Foundation Flink   1.3.16               Succeeded

NAME                  DISPLAY                 VERSION   REPLACES   PHASE
ibm-redis-cp.v1.1.6   ibm-redis-cp-operator   1.1.6                Succeeded

NAME                                 DISPLAY                               VERSION   REPLACES   PHASE
ibm-common-service-operator.v4.4.0   IBM Cloud Pak foundational services   4.4.0                Succeeded

NAME                                          DISPLAY                         VERSION                  REPLACES   PHASE
ibm-management-kong.v4.5.0-rc1-202403120045   IBM Internal - IBM AIOps Kong   4.5.0-rc1-202403120045              Succeeded

NAME                                                   DISPLAY        VERSION                  REPLACES   PHASE
ibm-watson-aiops-ui-operator.v4.5.0-rc1-202403120045   IBM AIOps UI   4.5.0-rc1-202403120045              Succeeded

NAME                              DISPLAY                       VERSION   REPLACES                          PHASE
cloud-native-postgresql.v1.18.7   EDB Postgres for Kubernetes   1.18.7    cloud-native-postgresql.v1.18.6   Succeeded

NAME                               DISPLAY            VERSION   REPLACES   PHASE
ibm-cert-manager-operator.v4.2.2   IBM Cert Manager   4.2.2                Succeeded

NAME                           DISPLAY         VERSION   REPLACES   PHASE
ibm-commonui-operator.v4.3.1   Ibm Common UI   4.3.1                Succeeded

NAME                         DISPLAY               VERSION   REPLACES   PHASE
ibm-events-operator.v4.9.0   IBM Events Operator   4.9.0                Succeeded

NAME                      DISPLAY           VERSION   REPLACES   PHASE
ibm-iam-operator.v4.4.0   IBM IM Operator   4.4.0                Succeeded

NAME                          DISPLAY                VERSION   REPLACES   PHASE
ibm-mongodb-operator.v4.2.2   IBM MongoDB Operator   4.2.2                Succeeded

NAME                      DISPLAY           VERSION   REPLACES   PHASE
ibm-zen-operator.v5.1.1   IBM Zen Service   5.1.1                Succeeded

NAME                                          DISPLAY                                VERSION   REPLACES   PHASE
operand-deployment-lifecycle-manager.v4.2.3   Operand Deployment Lifecycle Manager   4.2.3                Succeeded

______________________________________________________________
Subscriptions from cp4aiops namespace:

NAME                 PACKAGE              SOURCE                  CHANNEL
aimanager-operator   aimanager-operator   ibm-cp-waiops-catalog   v4.5

NAME                 PACKAGE              SOURCE                  CHANNEL
aiopsedge-operator   aiopsedge-operator   ibm-cp-waiops-catalog   v4.5

NAME           PACKAGE        SOURCE                  CHANNEL
asm-operator   asm-operator   ibm-cp-waiops-catalog   v4.5

NAME                  PACKAGE               SOURCE                  CHANNEL
ibm-management-kong   ibm-management-kong   ibm-cp-waiops-catalog   v4.5

NAME                           PACKAGE                        SOURCE                  CHANNEL
ibm-watson-aiops-ui-operator   ibm-watson-aiops-ui-operator   ibm-cp-waiops-catalog   v4.5

NAME             PACKAGE           SOURCE                  CHANNEL
ir-ai-operator   ibm-aiops-ir-ai   ibm-cp-waiops-catalog   v4.5

NAME               PACKAGE             SOURCE                  CHANNEL
ir-core-operator   ibm-aiops-ir-core   ibm-cp-waiops-catalog   v4.5

NAME                    PACKAGE                  SOURCE                  CHANNEL
ir-lifecycle-operator   ibm-aiops-ir-lifecycle   ibm-cp-waiops-catalog   v4.5

NAME           PACKAGE        SOURCE                  CHANNEL
ibm-redis-cp   ibm-redis-cp   ibm-cp-waiops-catalog   v1.1

NAME                     PACKAGE                  SOURCE                  CHANNEL
ibm-automation-elastic   ibm-automation-elastic   ibm-cp-waiops-catalog   v1.3

NAME                   PACKAGE                SOURCE                  CHANNEL
ibm-automation-flink   ibm-automation-flink   ibm-cp-waiops-catalog   v1.3

NAME                      PACKAGE                   SOURCE                  CHANNEL
cloud-native-postgresql   cloud-native-postgresql   ibm-cp-waiops-catalog   stable

NAME                         PACKAGE                     SOURCE                  CHANNEL
ibm-idp-config-ui-operator   ibm-commonui-operator-app   ibm-cp-waiops-catalog   v4.3

NAME                  PACKAGE               SOURCE                  CHANNEL
ibm-events-operator   ibm-events-operator   ibm-cp-waiops-catalog   v3

NAME              PACKAGE            SOURCE                  CHANNEL
ibm-im-operator   ibm-iam-operator   ibm-cp-waiops-catalog   v4.4

NAME                      PACKAGE                    SOURCE                  CHANNEL
ibm-im-mongodb-operator   ibm-mongodb-operator-app   ibm-cp-waiops-catalog   v4.2

NAME                      PACKAGE            SOURCE                  CHANNEL
ibm-platformui-operator   ibm-zen-operator   ibm-cp-waiops-catalog   v4.3

NAME                                       PACKAGE    SOURCE                  CHANNEL
operand-deployment-lifecycle-manager-app   ibm-odlm   ibm-cp-waiops-catalog   v4.2

NAME                        PACKAGE                       SOURCE                  CHANNEL
aiops-ibm-common-services   ibm-common-service-operator   ibm-cp-waiops-catalog   v4.4

______________________________________________________________
Subscriptions from openshift-operators namespace:

NAME                     PACKAGE                  SOURCE                  CHANNEL
ibm-aiops-orchestrator   ibm-aiops-orchestrator   ibm-cp-waiops-catalog   v4.5

______________________________________________________________
OperandRequest instances:

NAMESPACE   NAME                   PHASE     CREATED AT
cp4aiops    ibm-aiops-ai-manager   Running   2024-03-13T18:40:11Z

NAMESPACE   NAME                         PHASE     CREATED AT
cp4aiops    ibm-aiops-aiops-foundation   Running   2024-03-13T18:40:11Z

NAMESPACE   NAME              PHASE     CREATED AT
cp4aiops    ibm-iam-service   Running   2024-03-13T18:40:56Z

NAMESPACE   NAME              PHASE     CREATED AT
cp4aiops    ibm-iam-request   Running   2024-03-13T18:38:06Z

______________________________________________________________
AIOps certificate status:

NAME                       RENEWAL                READY   MESSAGE
aimanager-ca-certificate   2024-05-12T19:04:14Z   True    Certificate is up to date and has not expired

NAME                    RENEWAL                READY   MESSAGE
aimanager-certificate   2024-05-12T19:04:32Z   True    Certificate is up to date and has not expired

NAME                                               RENEWAL                READY   MESSAGE
aiops-ir-lifecycle-eventprocessor-ep-client-cert   2024-05-12T18:42:06Z   True    Certificate is up to date and has not expired

NAME                                                 RENEWAL                READY   MESSAGE
aiops-ir-lifecycle-eventprocessor-ep-internal-cert   2024-05-12T18:42:05Z   True    Certificate is up to date and has not expired

NAME                                         RENEWAL                READY   MESSAGE
aiops-ir-lifecycle-eventprocessor-ep-ss-ca   2024-05-12T18:41:36Z   True    Certificate is up to date and has not expired

NAME                                                  RENEWAL                READY   MESSAGE
aiops-ir-lifecycle-eventprocessor-ep-zk-client-cert   2024-05-07T18:41:33Z   True    Certificate is up to date and has not expired

NAME                            RENEWAL                READY   MESSAGE
aiops-topology-cassandra-cert   2030-11-11T02:42:57Z   True    Certificate is up to date and has not expired

NAME                    RENEWAL                READY   MESSAGE
aiopsedge-client-cert   2026-02-11T18:41:09Z   True    Certificate is up to date and has not expired

NAME          RENEWAL                READY   MESSAGE
aiopsedgeca   2026-02-11T18:41:09Z   True    Certificate is up to date and has not expired

NAME                                            RENEWAL                READY   MESSAGE
automationbase-sample-automationbase-ab-ss-ca   2024-05-12T18:37:05Z   True    Certificate is up to date and has not expired

NAME                    RENEWAL                READY   MESSAGE
common-web-ui-ca-cert   2024-12-16T18:38:56Z   True    Certificate is up to date and has not expired

NAME                             RENEWAL                READY   MESSAGE
connector-bridge-cert-ca9e3e1a   2025-07-13T10:44:12Z   True    Certificate is up to date and has not expired

NAME                                               RENEWAL                READY   MESSAGE
cp4waiops-eventprocessor-eve-29ee-ep-client-cert   2024-05-12T18:41:15Z   True    Certificate is up to date and has not expired

NAME                                                 RENEWAL                READY   MESSAGE
cp4waiops-eventprocessor-eve-29ee-ep-internal-cert   2024-05-12T18:41:15Z   True    Certificate is up to date and has not expired

NAME                                         RENEWAL                READY   MESSAGE
cp4waiops-eventprocessor-eve-29ee-ep-ss-ca   2024-05-12T18:40:36Z   True    Certificate is up to date and has not expired

NAME                RENEWAL                READY   MESSAGE
cs-ca-certificate   2025-07-13T10:37:32Z   True    Certificate is up to date and has not expired

NAME                                      RENEWAL                READY   MESSAGE
iaf-system-elasticsearch-es-client-cert   2024-05-12T18:39:06Z   True    Certificate is up to date and has not expired

NAME                                RENEWAL                READY   MESSAGE
iaf-system-elasticsearch-es-ss-ca   2024-05-12T18:38:34Z   True    Certificate is up to date and has not expired

NAME                                    RENEWAL                READY   MESSAGE
ibm-cp-aiops-edb-postgres-client-cert   2024-05-12T18:40:36Z   True    Certificate is up to date and has not expired

NAME                                    RENEWAL                READY   MESSAGE
ibm-cp-aiops-edb-postgres-server-cert   2024-05-12T18:40:41Z   True    Certificate is up to date and has not expired

NAME                              RENEWAL                READY   MESSAGE
ibm-cp-aiops-edb-postgres-ss-ca   2024-05-12T18:40:31Z   True    Certificate is up to date and has not expired

NAME                             RENEWAL                READY   MESSAGE
ibm-cp-aiops-redis-client-cert   2024-05-12T18:35:13Z   True    Certificate is up to date and has not expired

NAME                             RENEWAL                READY   MESSAGE
ibm-cp-aiops-redis-server-cert   2024-05-12T18:35:13Z   True    Certificate is up to date and has not expired

NAME                       RENEWAL                READY   MESSAGE
ibm-cp-aiops-redis-ss-ca   2024-05-12T18:34:57Z   True    Certificate is up to date and has not expired

NAME                                RENEWAL                READY   MESSAGE
ibm-zen-metastore-edb-certificate   2024-05-12T18:49:25Z   True    Certificate is up to date and has not expired

NAME                      RENEWAL                READY   MESSAGE
icp-mongodb-client-cert   2025-07-13T10:39:18Z   True    Certificate is up to date and has not expired

NAME                     RENEWAL                READY   MESSAGE
identity-provider-cert   2024-12-16T18:38:24Z   True    Certificate is up to date and has not expired

NAME                       RENEWAL                READY   MESSAGE
internal-tls-certificate   2024-05-12T18:43:41Z   True    Certificate is up to date and has not expired

NAME                              RENEWAL                READY   MESSAGE
internal-tls-pkcs12-certificate   2024-05-12T18:43:28Z   True    Certificate is up to date and has not expired

NAME                             RENEWAL                READY   MESSAGE
internal-tls-pkcs8-certificate   2024-05-12T18:43:24Z   True    Certificate is up to date and has not expired

NAME                   RENEWAL                READY   MESSAGE
mongodb-root-ca-cert   2025-07-13T10:39:15Z   True    Certificate is up to date and has not expired

NAME                 RENEWAL                READY   MESSAGE
platform-auth-cert   2024-12-16T18:38:32Z   True    Certificate is up to date and has not expired

NAME                           RENEWAL                READY   MESSAGE
platform-identity-management   2024-12-16T18:38:31Z   True    Certificate is up to date and has not expired

NAME             RENEWAL                READY   MESSAGE
saml-auth-cert   2024-12-16T18:38:36Z   True    Certificate is up to date and has not expired

NAME                                           RENEWAL                READY   MESSAGE
zen-metastore-edb-replica-client-certificate   2024-05-12T18:43:39Z   True    Certificate is up to date and has not expired

NAME                                   RENEWAL                READY   MESSAGE
zen-metastore-edb-server-certificate   2025-02-11T18:43:38Z   True    Certificate is up to date and has not expired

NAME                    RENEWAL                READY   MESSAGE
zen-minio-certificate   2025-03-13T18:44:45Z   True    Certificate is up to date and has not expired

______________________________________________________________
ODLM pod current status:

cp4aiops                                           operand-deployment-lifecycle-manager-6694f56f48-gsvw5             1/1     Running     0               65m
______________________________________________________________
Orchestrator pod current status:

openshift-operators                                ibm-aiops-orchestrator-controller-manager-7d86b988db-zk7h6        1/1     Running     0               70m
```