### PR TITLE
Update Db2u and use x-small Cognos

### DIFF
--- a/aiops-cognos-analytics/4.5/roles/aiops/defaults/main.yml
+++ b/aiops-cognos-analytics/4.5/roles/aiops/defaults/main.yml
@@ -1,4 +1,4 @@
-aiops_channel: "v4.4"
+aiops_channel: "v4.5"
 aiops_package: ibm-aiops-orchestrator
 aiops_instance: ibm-cp-aiops
 aiops_namespace: "cp4aiops"

--- a/aiops-cognos-analytics/4.5/roles/aiops/tasks/main.yml
+++ b/aiops-cognos-analytics/4.5/roles/aiops/tasks/main.yml
@@ -54,10 +54,6 @@
         installPlanApproval: "{{approval_type}}"
         source: "{{ aiops_catalog_name }}"
         sourceNamespace: "{{ aiops_catalog_namespace }}"
-        config:
-          env:
-          - name: BEDROCKV4
-            value: "true"
 
 - name: be sure AIOps Subscription is AtLatestKnown
   when: installaiops is defined and installaiops
@@ -114,20 +110,13 @@
         license:
           accept: "{{ licenseaccept }}"
         pakModules: 
-        - config:
-          - enabled: false
-            name: ibm-watson-aiops-ui-operator
-          - enabled: false
-            name: redis
-          - enabled: false
-            name: ibm-management-kong
-          enabled: true # Enable Bedrock, but disable other AIOps components for testing
+        - enabled: true
           name: aiopsFoundation 
-        - enabled: false # Disable AIOps components for testing
+        - enabled: true
           name: applicationManager
-        - enabled: false # Disable AIOps components for testing
+        - enabled: true
           name: aiManager
-        - enabled: false # Disable AIOps components for testing
+        - enabled: false
           name: connection
         size: "{{ aiops_size }}"
         storageClass: "{{ file_storageclass }}"

--- a/aiops-cognos-analytics/4.5/roles/cognosanalytics/defaults/main.yml
+++ b/aiops-cognos-analytics/4.5/roles/cognosanalytics/defaults/main.yml
@@ -21,8 +21,8 @@ licenseaccept: false
 # provision
 reprovision_cognos: true
 provision_timeout: 60
-plan_size: "fixedminimum"
-content_store: 'DB2' # only 'DB2' (must be capitalized!) right now, want to use postgresql
+plan_size: "xsmall"
+content_store: 'DB2' # only 'DB2' (must be capitalized!)
 content_store_db_url: "c-db2u-db01-db2u"
 content_store_db_name: "BLUDB"
 content_store_db_port: "50000"

--- a/aiops-cognos-analytics/4.5/vars.yml
+++ b/aiops-cognos-analytics/4.5/vars.yml
@@ -20,8 +20,8 @@ db2_cpu_requests: "2000m"
 db2_cpu_limits: "4000m"
 db2_memory_requests: "2Gi"
 db2_memory_limits: "4Gi"
-db2_affinity_key: "" # To schedule DB2 to specific nodes; DB2 cannot schedule reliably to nodes with >32Gi of memory
-db2_affinity_value: "" # To schedule DB2 to specific nodes; DB2 cannot schedule reliably to nodes with >32Gi of memory
+db2_affinity_key: "" # To schedule DB2 to specific nodes
+db2_affinity_value: "" # To schedule DB2 to specific nodes
 db2_registry: "cp.icr.io"
 # Cognos Analytics
 ca_name: "cp4aiops"

--- a/aiops-cognos-analytics/4.5/vars.yml
+++ b/aiops-cognos-analytics/4.5/vars.yml
@@ -10,7 +10,7 @@ aiops_instance: ibm-cp-aiops
 waitforinstall: yes # wait for the aiops installation resource to have status.phase == Running
 # DB2
 db2_instance_name: db2u-db01
-db2_version: "s11.5.9.0"
+db2_version: "s11.5.9.0-cn1"
 db2_data_storage_class: "ocs-storagecluster-ceph-rbd" # Block
 db2_logs_storage_class: "ocs-storagecluster-ceph-rbd" # Block
 db2_temp_storage_class: "ocs-storagecluster-ceph-rbd" # Block


### PR DESCRIPTION
* Update from Db2u `s11.5.9.0` to `s11.5.9.0-cn1` to resolve failures when Db2u pods are scheduled on nodes with >32Gi memory
* Use x-small Cognos instance to reduce footprint