### PR TITLE
remove upgrade as upgrade option needs to be reworked

### DIFF
--- a/prereq-checker/3.6/Readme.md
+++ b/prereq-checker/3.6/Readme.md
@@ -2,7 +2,7 @@
 
 # IBM Cloud Pak for Watson AIOps AI Manager prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
@@ -25,7 +25,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/3.6
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for Watson AIOps AI Manager.
 ```
@@ -36,11 +36,6 @@ ex: oc project cp4waiops
 To run the prerequisite checker tool, run the following command:
 ```
   ./prereq.sh
-```
-
-To run the upgrade checker tool, run the following command:
-```
-  ./prereq.sh -u
 ```
 
 To run the upgrade checker tool and install upgrade requirements, if needed, run the following command:

--- a/prereq-checker/3.6/prereq.sh
+++ b/prereq-checker/3.6/prereq.sh
@@ -83,25 +83,6 @@ display_help() {
    echo "*******************************************************************************************"
 }
 
-# Upgrade: Check if the user is doing an upgrade
-checkUpgrade () {
-  echo
-    log $INFO "Starting IBM Cloud Pak for Watson AIOps AI Manager upgrade checker..."
-  echo
-  ORCHESTRATOR_UPGRADE="true"
-
-  OPS_NAMESPACE="openshift-operators"
-  INSTALL_NAMESPACE=`oc project -q`
-
-  ORCHESTRATOR_CHECK1=`oc get subscription.operator --ignore-not-found -n $INSTALL_NAMESPACE -o=jsonpath="{range .items[*]}{.spec.name}{'\n'}{end}" | grep ibm-aiops-orchestrator`
-
-  ORCHESTRATOR_CHECK2=`oc get subscription.operator --ignore-not-found -n $OPS_NAMESPACE -o=jsonpath="{range .items[*]}{.spec.name}{'\n'}{end}" | grep ibm-aiops-orchestrator`
-
-  if [[ $ORCHESTRATOR_CHECK1 || $ORCHESTRATOR_CHECK2 ]] ; then
-    checkIAFSubs
-  fi
-}
-
 # Upgrade: Check IAF subscription
 checkIAFSubs () {
 NUM_SUBS=`oc get subscription.operator --ignore-not-found -n $OPS_NAMESPACE -o=jsonpath="{range .items[*]}{.spec.name}{'\n'}{end}" | grep ibm-automation | wc -l || true`
@@ -154,11 +135,8 @@ while getopts 'hsuo' opt; do
       display_help
       exit 0
       ;;
-    u)
-      checkUpgrade
-      ;;
     s)
-      SKIP_CONFIRM="true" && checkUpgrade
+      SKIP_CONFIRM="true"
       ;;
     o)
       SKIP_STORAGE_CHECK="true"

--- a/prereq-checker/3.7/README.md
+++ b/prereq-checker/3.7/README.md
@@ -2,7 +2,7 @@
 
 # IBM Cloud Pak for Watson AIOps AI Manager prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
@@ -31,7 +31,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/3.7
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for Watson AIOps AI Manager.
 ```

--- a/prereq-checker/4.1/README.md
+++ b/prereq-checker/4.1/README.md
@@ -2,7 +2,7 @@
 
 # IBM Cloud Pak for Watson AIOps AI Manager prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for Watson AIOps AI Manager. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
@@ -29,7 +29,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/4.2
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for Watson AIOps AI Manager.
 ```

--- a/prereq-checker/4.2/Readme.md
+++ b/prereq-checker/4.2/Readme.md
@@ -1,6 +1,6 @@
 # IBM Cloud Pak for AIOps prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
@@ -26,7 +26,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/4.2
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for AIOps.
 ```

--- a/prereq-checker/4.3/Readme.md
+++ b/prereq-checker/4.3/Readme.md
@@ -1,6 +1,6 @@
 # IBM Cloud Pak for AIOps prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
@@ -33,7 +33,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/4.3
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for AIOps.
 ```

--- a/prereq-checker/4.4/Readme.md
+++ b/prereq-checker/4.4/Readme.md
@@ -1,6 +1,6 @@
 # IBM Cloud Pak for AIOps prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
@@ -36,7 +36,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/4.4
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for AIOps.
 ```

--- a/prereq-checker/4.5/Readme.md
+++ b/prereq-checker/4.5/Readme.md
@@ -1,17 +1,17 @@
 # IBM Cloud Pak for AIOps prerequisite checker tool
 
-The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation or upgrade of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
+The prerequisite checker tool can be used to validate whether a Red Hat OpenShift Container Platform cluster has the required resources and prerequisites available to enable a successful installation of IBM Cloud Pak for AIOps AIOps. This tool completes the following checks and generates an installation readiness report:
 
 **Pre-Install Checker::**
 
-- **OpenShift version check** : Checks whether the Red Hat OpenShift Container Platform cluster version is supported for IBM Cloud Pak for AIOps. The following OCP versions are compatible with 4.5.0:
+- **OpenShift version check** : Checks whether the Red Hat OpenShift Container Platform cluster version is supported for IBM Cloud Pak for AIOps. The following OCP versions are compatible with 4.5.1:
   - v4.12
   - v4.13
   - v4.14 (homogenous cluster only)
   - v4.15 (homogenous cluster only)
 
 
-- **Storage check**: Checks whether a storage class that uses a supported storage provider (Portworx, Red Hat Openshift Data Foundation (ODF), Storage Fusion or IBMC-file-gold-gid) is available on the cluster. For more information, see the IBM Documentation [Storage considerations](https://ibm.biz/storage_consideration_450).
+- **Storage check**: Checks whether a storage class that uses a supported storage provider (Portworx, Red Hat Openshift Data Foundation (ODF), Storage Fusion or IBMC-file-gold-gid) is available on the cluster. For more information, see the IBM Documentation [Storage considerations](https://ibm.biz/storage_consideration_451).
 
 **NOTE: If you plan to use Storage Fusion with AIOPS, please keep in mind the following OCP version dependencies**
 | Storage Fusion Version     | OCP Versions supported |
@@ -19,11 +19,11 @@ The prerequisite checker tool can be used to validate whether a Red Hat OpenShif
 | Storage Fusion v2.7        | v4.12, v4.13, v4.14              |
 
 
-- **Small or large profile install check**: Checks whether the cluster has enough resources (vCPU, Memory, and Nodes) for installing a small or large profile of IBM Cloud Pak for AIOps. For more information, see the IBM Documentation [Hardware requirements](https://ibm.biz/aiops_hardware_450).
+- **Small or large profile install check**: Checks whether the cluster has enough resources (vCPU, Memory, and Nodes) for installing a small or large profile of IBM Cloud Pak for AIOps. For more information, see the IBM Documentation [Hardware requirements](https://ibm.biz/aiops_hardware_451).
 
 Note: Only nodes that have AMD64 will only be calculated.
 
-- **Entitlement Secret check**: Checks whether a secret called ibm-entitlement-key or a global pull secret called pull-secret (global pull secret found in openshift-config namespace) have been created. For more information, see the IBM Documentation [Entitlement Keys](https://ibm.biz/storage_consideration_450)
+- **Entitlement Secret check**: Checks whether a secret called ibm-entitlement-key or a global pull secret called pull-secret (global pull secret found in openshift-config namespace) have been created. For more information, see the IBM Documentation [Entitlement Keys](https://ibm.biz/storage_consideration_451)
 
 - **Cert Manager Operator Check**: Ensures a Cert Manager Operator is installed
 
@@ -40,7 +40,7 @@ Clone the following GitHub repository:
   cd cp4waiops-samples/prereq-checker/4.5
 ```
 
-## Running the prerequisite & upgrade checker tool script
+## Running the prerequisite checker tool script
 
 **IMPORTANT:** Before you run the script make sure that you are in the namespace where you have installed or are planning to install IBM Cloud Pak for AIOps.
 ```


### PR DESCRIPTION
## Overview
In 3.6 we removed the upgrade option from the prereq script as that version required less resources than the previous version. This resulted in negative calculations.

We are devising a better way to calculate upgrade especially with some upcoming work that we have in store in a future release.