### PR TITLE
fix: cognos widget bugs

### DIFF
--- a/aiops-cognos-analytics/integration/setupCognos.sh
+++ b/aiops-cognos-analytics/integration/setupCognos.sh
@@ -33,7 +33,7 @@ sessionKey=
 function setDefaults() {
   current_context=$(kubectl config view -n ${aiopsNamespace} -o jsonpath={.current-context} | awk -F/ '{ print $2 }')
   default=${current_context#api-}
-  default=${default%%-*}
+  default=${default%%-cp*}
   default=${default:-aiops-2-cognos}
   if [ -z $client ]; then
     client=$default

--- a/aiops-cognos-analytics/widgets/button/ButtonWidget.js
+++ b/aiops-cognos-analytics/widgets/button/ButtonWidget.js
@@ -29,6 +29,9 @@ class Renderer extends BaseRenderer {
     super.initialize().then(() => {
       this.filterViewAPI = new FilterViewAPI({options: ['filter'], type: 'alert', proxyHost: this.proxyHost});
       this.alertSummaryAPI = new AlertSummaryAPI({groupBy: ['severity'], proxyHost: this.proxyHost});
+      const filterId = this.content.getPropertyValue('dropdownFilter');
+      const buttonShape = this.content.getPropertyValue('dropdownShape');
+      return this.getAlertSummaryAndUpdateButton({filterId, buttonShape})
     });
   }
 

--- a/aiops-cognos-analytics/widgets/common/getProxy.js
+++ b/aiops-cognos-analytics/widgets/common/getProxy.js
@@ -57,6 +57,23 @@ const getProxyForDashboard = async (id) => {
   return url.protocol + '//' + url.host;
 };
 
+// Avoid CORS error on initial render
+const prefetchZen = async (proxyHost) => {
+  try {
+    await fetch(proxyHost + '/zen', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Origin': window.location.origin
+      },
+      mode: 'no-cors',
+      credentials: 'include'
+    });
+  } catch (e) {
+    console.warn('[prefetchZen] failed', e);
+  }
+};
+
 class ProxyManager {
   constructor() {
     if (instance) {
@@ -73,6 +90,7 @@ class ProxyManager {
     if (cached) return cached;
 
     globalState[namespace] = await getProxyForDashboard(namespace);
+    await prefetchZen(globalState[namespace]);
     return globalState[namespace];
   }
 }


### PR DESCRIPTION
Fix a few bugs with Cognos dashboard integration:
- Default namespace with embedded dashes
- Empty button widget
- Cors error on initial render of alert or incident list widget