### PR TITLE
Fixing yaml alignment in previous releases

### DIFF
--- a/bcdr/4.12.0/restore/aiops-restore-job.yaml
+++ b/bcdr/4.12.0/restore/aiops-restore-job.yaml
@@ -7,8 +7,6 @@ spec:
   backoffLimit: 0
   template:
     spec:
-      imagePullSecrets:
-        - name: restore-secret
       serviceAccountName: restore-sa
       volumes:
         - name: restore-data-config

--- a/bcdr/4.12.0/restore/ia-restore-job.yaml
+++ b/bcdr/4.12.0/restore/ia-restore-job.yaml
@@ -18,21 +18,21 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4waiops-bcdr@sha256:7262f64be3f1d0c9bf425866f454f4c8f0e424b7a2af86c5328995886a4a55ed"
-          imagePullPolicy: Always
-          name: ia-restore
-          command: ["/bin/bash", "/bcdr/restore/restore.sh","-ia"]
-          resources: {}
-          env:
-          - name: WORKDIR
-            value: "/bcdr"
-          volumeMounts:
-            - name: restore-data-config
-              mountPath: /bcdr/restore/restore-data.json
-              subPath: restore-data.json 
-            - name: aiops-config
-              mountPath: /bcdr/common/aiops-config.json
-              subPath: aiops-config.json
-            - mountPath: /workdir
-              name: workdir
+      - image: "icr.io/cpopen/cp4waiops/cp4waiops-bcdr@sha256:7262f64be3f1d0c9bf425866f454f4c8f0e424b7a2af86c5328995886a4a55ed"
+        imagePullPolicy: Always
+        name: ia-restore
+        command: ["/bin/bash", "/bcdr/restore/restore.sh","-ia"]
+        resources: {}
+        env:
+        - name: WORKDIR
+          value: "/bcdr"
+        volumeMounts:
+          - name: restore-data-config
+            mountPath: /bcdr/restore/restore-data.json
+            subPath: restore-data.json 
+          - name: aiops-config
+            mountPath: /bcdr/common/aiops-config.json
+            subPath: aiops-config.json
+          - mountPath: /workdir
+            name: workdir
       restartPolicy: Never

--- a/bcdr/4.13.0/restore/aiops-restore-job.yaml
+++ b/bcdr/4.13.0/restore/aiops-restore-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:213ea4bfba4ef2296e6dc34735494d97f07261c9e34b07d7c94edb66c5bba8b7"
+      - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:213ea4bfba4ef2296e6dc34735494d97f07261c9e34b07d7c94edb66c5bba8b7"
         imagePullPolicy: Always
         name: aiops-restore
         command: ["/bin/bash", "/bcdr/restore/restore.sh","-aiops"]

--- a/bcdr/4.13.0/restore/ia-restore-job.yaml
+++ b/bcdr/4.13.0/restore/ia-restore-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:213ea4bfba4ef2296e6dc34735494d97f07261c9e34b07d7c94edb66c5bba8b7"
+      - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:213ea4bfba4ef2296e6dc34735494d97f07261c9e34b07d7c94edb66c5bba8b7"
         imagePullPolicy: Always
         name: ia-restore
         command: ["/bin/bash", "/bcdr/restore/restore.sh","-ia"]

--- a/bcdr/4.13.0/restore/ns-restore-job.yaml
+++ b/bcdr/4.13.0/restore/ns-restore-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:213ea4bfba4ef2296e6dc34735494d97f07261c9e34b07d7c94edb66c5bba8b7"
+      - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:213ea4bfba4ef2296e6dc34735494d97f07261c9e34b07d7c94edb66c5bba8b7"
         imagePullPolicy: Always
         name: namespace-restore
         command: ["/bin/bash", "/bcdr/restore/restore.sh","-ns"]

--- a/bcdr/4.13.1/restore/aiops-restore-job.yaml
+++ b/bcdr/4.13.1/restore/aiops-restore-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:2a8a06a2b0a10af0c4ae0ea294782e288cc36f966663ea9e18beed73f2adbd34"
+      - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:2a8a06a2b0a10af0c4ae0ea294782e288cc36f966663ea9e18beed73f2adbd34"
         imagePullPolicy: Always
         name: aiops-restore
         command: ["/bin/bash", "/bcdr/restore/restore.sh","-aiops"]

--- a/bcdr/4.13.1/restore/ia-restore-job.yaml
+++ b/bcdr/4.13.1/restore/ia-restore-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:2a8a06a2b0a10af0c4ae0ea294782e288cc36f966663ea9e18beed73f2adbd34"
+      - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:2a8a06a2b0a10af0c4ae0ea294782e288cc36f966663ea9e18beed73f2adbd34"
         imagePullPolicy: Always
         name: ia-restore
         command: ["/bin/bash", "/bcdr/restore/restore.sh","-ia"]

--- a/bcdr/4.13.1/restore/ns-restore-job.yaml
+++ b/bcdr/4.13.1/restore/ns-restore-job.yaml
@@ -18,7 +18,7 @@ spec:
         - name: workdir
           emptyDir: {}
       containers:
-        - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:2a8a06a2b0a10af0c4ae0ea294782e288cc36f966663ea9e18beed73f2adbd34"
+      - image: "icr.io/cpopen/cp4waiops/cp4aiops-bcdr@sha256:2a8a06a2b0a10af0c4ae0ea294782e288cc36f966663ea9e18beed73f2adbd34"
         imagePullPolicy: Always
         name: namespace-restore
         command: ["/bin/bash", "/bcdr/restore/restore.sh","-ns"]


### PR DESCRIPTION
A customer reported a problem with the restore yaml file in 4.13.1 where the yaml alignment wasn't correct. I found the same problem in 4.13.0, and something similar in one of the restore yaml files in 4.12.0.
All 3 releases were corrected. 