### PR TITLE
Version numbers update

### DIFF
--- a/bcdr/5.1.5/backup/helm/templates/backup-config.yaml
+++ b/bcdr/5.1.5/backup/helm/templates/backup-config.yaml
@@ -399,7 +399,7 @@ data:
       "oadpNamespace": "{{ .Values.oadpNamespace }}",
       "backupNameSuffix": "{{ .Values.backupNameSuffix }}",
       "rwxStorageClass": "{{ .Values.rwxStorageClass}}",
-      "aiopsVersion": "0.1.0"
+      "aiopsVersion": "5.1.5"
     }
 kind: ConfigMap
 metadata:

--- a/bcdr/5.1.5/restore/helm/templates/restore-config.yaml
+++ b/bcdr/5.1.5/restore/helm/templates/restore-config.yaml
@@ -10,7 +10,7 @@ data:
       "csNamespace": "{{ .Values.csNamespace }}",
       "oadpNamespace": "{{ .Values.oadpNamespace }}",
       "rwxStorageClass": "{{ .Values.rwxStorageClass}}",
-      "aiopsVersion": "0.1.0"
+      "aiopsVersion": "5.1.5"
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
The version numbers for 5.1.5 were not updated successfully by the new automated process introduced for 5.1.5.
I've made a note to double check this for the next release. 