### PR TITLE
Fix topology endpoint changes

### DIFF
--- a/geo-redundancy-scripts/.gitignore
+++ b/geo-redundancy-scripts/.gitignore
@@ -1,3 +1,3 @@
 # Exclude actual configuration files (keep template only)
 **/geo_config.env
-
+topology-export.json

--- a/geo-redundancy-scripts/v1/common_functions.sh
+++ b/geo-redundancy-scripts/v1/common_functions.sh
@@ -181,6 +181,48 @@ get_jwt_token() {
 }
 
 # ============================================
+# Resolve Topology API Base Path
+# ============================================
+# Usage: resolve_topology_endpoint
+# Requires: CLUSTER_CPD_ENDPOINT and JWT_TOKEN must be set (call after login_and_get_token)
+# Sets: TOPOLOGY_API_BASE — the base path prefix used for topology backup/restore calls.
+#
+# Tries the new endpoint first:
+#   /aiops/api/v2/topology/service/info
+# Falls back to the legacy endpoint on a 404 response:
+#   /aiops/api/v2/configuration/topology/config
+#
+# The result is cached in TOPOLOGY_API_BASE so this probe runs only once per
+# script execution regardless of how many topology calls follow.
+resolve_topology_endpoint() {
+    # Return immediately if already resolved
+    if [ -n "${TOPOLOGY_API_BASE:-}" ]; then
+        return 0
+    fi
+
+    # New endpoint is for version 5.2.0 of Concert Operate and after
+    local new_base="/aiops/api/v2/topology/service/info"
+
+    # Legacy endpoint is for version 5.1.x of Concert Operate
+    local legacy_base="/aiops/api/v2/configuration/topology/config"
+
+    echo "Detecting topology API endpoint..."
+    local http_code
+    http_code=$(curl -k -s -o /dev/null -w "%{http_code}" \
+        -X GET "${CLUSTER_CPD_ENDPOINT}${new_base}/backup" \
+        --header "Authorization: Bearer ${JWT_TOKEN}" \
+        --header "X-TenantID: cfd95b7e-3bc7-4006-a4a8-a73a79c71255")
+
+    if [ "${http_code}" -eq 404 ]; then
+        echo "New topology endpoint not available (HTTP ${http_code}), falling back to: ${legacy_base}"
+        TOPOLOGY_API_BASE="${legacy_base}"
+    else
+        echo "Topology endpoint detected (HTTP ${http_code}): ${new_base}"
+        TOPOLOGY_API_BASE="${new_base}"
+    fi
+}
+
+# ============================================
 # Login and Get Token (Combined)
 # ============================================
 # Usage: login_and_get_token "primary|backup"

--- a/geo-redundancy-scripts/v1/exportTopology.sh
+++ b/geo-redundancy-scripts/v1/exportTopology.sh
@@ -58,6 +58,7 @@ load_geo_config
 CLUSTER_DISPLAY=$(echo "$SOURCE_CLUSTER" | tr '[:lower:]' '[:upper:]')
 echo "Exporting topology from ${CLUSTER_DISPLAY} cluster..."
 login_and_get_token "$SOURCE_CLUSTER"
+resolve_topology_endpoint
 
 # ============================================
 # Export Topology Configuration
@@ -66,7 +67,7 @@ OUTPUT_FILE="topology-export.json"
 OUTPUT_FILE_TMP="${OUTPUT_FILE}.tmp"
 echo "Exporting topology configuration to ${OUTPUT_FILE}..."
 
-curl -k -X GET "${CLUSTER_CPD_ENDPOINT}/aiops/api/v2/configuration/topology/config/backup" \
+curl -k -X GET "${CLUSTER_CPD_ENDPOINT}${TOPOLOGY_API_BASE}/backup" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer ${JWT_TOKEN}" \
   --header "X-TenantID: cfd95b7e-3bc7-4006-a4a8-a73a79c71255" \

--- a/geo-redundancy-scripts/v1/importTopology.sh
+++ b/geo-redundancy-scripts/v1/importTopology.sh
@@ -79,6 +79,7 @@ load_geo_config
 CLUSTER_DISPLAY=$(echo "$TARGET_CLUSTER" | tr '[:lower:]' '[:upper:]')
 echo "Importing topology to ${CLUSTER_DISPLAY} cluster..."
 login_and_get_token "$TARGET_CLUSTER"
+resolve_topology_endpoint
 
 # ============================================
 # Import Topology Configuration
@@ -89,7 +90,7 @@ echo "Importing topology configuration from ${INPUT_FILE}..."
 TOPOLOGY_DATA=$(cat "${INPUT_FILE}")
 
 # Import topology configuration
-HTTP_CODE=$(curl -k -X POST "${CLUSTER_CPD_ENDPOINT}/aiops/api/v2/configuration/topology/config/restore" \
+HTTP_CODE=$(curl -k -X POST "${CLUSTER_CPD_ENDPOINT}${TOPOLOGY_API_BASE}/restore" \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer ${JWT_TOKEN}" \
   --header "X-TenantID: cfd95b7e-3bc7-4006-a4a8-a73a79c71255" \
@@ -109,7 +110,7 @@ else
   # Try to get error details
   echo ""
   echo "Attempting to get error details..."
-  curl -k -X POST "${CLUSTER_CPD_ENDPOINT}/aiops/api/v2/configuration/topology/config/restore" \
+  curl -k -X POST "${CLUSTER_CPD_ENDPOINT}${TOPOLOGY_API_BASE}/restore" \
     --header "Content-Type: application/json" \
     --header "Authorization: Bearer ${JWT_TOKEN}" \
     --header "X-TenantID: cfd95b7e-3bc7-4006-a4a8-a73a79c71255" \


### PR DESCRIPTION
The topology endpoint has changed from 5.1.x to 5.2. This script change will attempt to call the newer endpoint first. If it fails, it will fallback to the legacy endpoint.

Output for 5.1.x
```log
JWT token obtained successfully
Detecting topology API endpoint...
New topology endpoint not available (HTTP 404), falling back to: /aiops/api/v2/configuration/topology/config
Exporting topology configuration to topology-export.json...
Formatting JSON...
Topology configuration exported successfully from primary cluster!
Output file: topology-export.json
File size: 8495 bytes
```

Output for 5.2.0
```log
JWT token obtained successfully
Detecting topology API endpoint...
Topology endpoint detected (HTTP 200): /aiops/api/v2/topology/service/info
Exporting topology configuration to topology-export.json...
Formatting JSON...
Topology configuration exported successfully from primary cluster!
Output file: topology-export.json
File size: 28374 bytes
```